### PR TITLE
feat: 타이포그래피 추가 정의 및 전역 레이아웃 구축

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,15 @@
   letter-spacing: var(--letter-spacing-1);
 }
 
+/* Body1 (bold) */
+.font-body-1-b {
+  font-family: var(--font-main);
+  font-size: var(--font-size-24);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-normal);
+  letter-spacing: var(--letter-spacing-1);
+}
+
 /* Body1 (semibold) */
 .font-body-1-sm {
   font-family: var(--font-main);

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,10 +3,12 @@ import { Outlet } from 'react-router-dom';
 
 const RootLayout = () => {
   return (
-    <div className="flex flex-col min-h-screen">
-      <NavBar />
-      <Outlet />
-    </div>
+    <main className="mx-auto min-w-768 max-w-1920 w-full h-screen overflow-auto">
+      <div className="min-w-max min-h-screen flex flex-col">
+        <NavBar />
+        <Outlet />
+      </div>
+    </main>
   );
 };
 

--- a/src/types/designToken.ts
+++ b/src/types/designToken.ts
@@ -46,6 +46,9 @@ export type TypographyToken =
   | 'font-heading-2'
   | 'font-heading-3'
 
+  /* Body (bold) */
+  | 'font-body-1-b'
+
   /* Body (semibold) */
   | 'font-body-1-sm'
   | 'font-body-2-sm'


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #6 

## 🔍 구현한 내용

- 최소 너비 제한 (min-w-768): 태블릿 미만(모바일) 환경에서 UI 요소가 겹치거나 깨지는 것을 방지하기 위해 최소 너비를 고정했습니다.
- 가로 스크롤 전략: 768px 미만 기기 접속 시, 레이아웃을 강제로 축소하지 않고 PC/태블릿 버전의 뷰를 가로 스크롤로 제공하도록 `overflow-auto`와 `min-w-max` 처리를 완료했습니다.
- 최대 너비 및 중앙 정렬: 대형 모니터 대응을 위해 `max-w-1920`과 `mx-auto`를 적용하여 콘텐츠가 중앙에 배치되도록 했습니다.

- 헤더에 사용되는 폰트가 타이포에 없어 따로 추가했습니다.

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/dde5b733-7c8c-42e0-bc72-ee1bde4ce5c2



## 📢 리뷰어에게
모바일 환경에서 사용자가 좌우로 스크롤하며 PC 뷰를 이용하는 데 불편함이 없는지 확인 부탁드립니다. 추후 페이지 퍼블리싱하며 레이아웃 수정이 일어날 수 있긴 한 점 감안부탁드립니다. 우선 UI 작업이 급해 레이아웃 PR 먼저 올립니다.