### PR TITLE
feat: 라이프스타일 태그 컴포넌트 구현

### DIFF
--- a/src/components/Lifestyle/LifestyleTag.tsx
+++ b/src/components/Lifestyle/LifestyleTag.tsx
@@ -1,0 +1,45 @@
+type LifestyleTagProps = {
+  label: string;
+  selected?: boolean;
+  onClick?: () => void;
+};
+
+const LifestyleTag = ({ label, selected = false, onClick }: LifestyleTagProps) => {
+  const hasSlash = label.includes('/');
+  let content: React.ReactNode = label;
+
+  if (hasSlash) {
+    const [left, right] = label.split('/');
+    content = (
+      <span className="inline-flex items-center">
+        <span>{left}</span>
+        <span className="mx-2" style={{ letterSpacing: '0.1em' }}>
+          /
+        </span>
+        <span>{right}</span>
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+      inline-flex items-center self-start justify-center
+      px-20 py-12 rounded-card bg-white cursor-pointer
+      transition-all duration-150 origin-left
+      ${
+        selected
+          ? 'border-shadow-blue font-heading-1 text-blue-700'
+          : 'border-shadow-black font-heading-2 text-black hover:text-blue-500'
+      }
+    `}
+    >
+      {'#\u00A0'}
+      {content}
+    </button>
+  );
+};
+
+export default LifestyleTag;

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,17 @@
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.2) 100%);
 }
 
+/* 태그 뒤 그림자 */
+@layer utilities {
+  .border-shadow-black {
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  .border-shadow-blue {
+    box-shadow: 0 0 7px 0 var(--color-blue-400);
+  }
+}
+
 @font-face {
   font-family: 'KIMM_Bold';
   src: url('./assets/fonts/KIMM_bold.woff2') format('woff2');

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,10 +3,10 @@ import { Outlet } from 'react-router-dom';
 
 const RootLayout = () => {
   return (
-    <main className="mx-auto min-w-1440 max-w-1920 w-full min-h-screen">
-      <div className="min-w-max flex flex-col">
-        <HomeIndicator />
-        <div className="pt-108">
+    <main className="mx-auto min-w-1440 max-w-1920 w-full h-screen">
+      <HomeIndicator />
+      <div className="pt-108 h-full">
+        <div className="h-[calc(100vh-108px)]">
           <Outlet />
         </div>
       </div>

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -3,10 +3,10 @@ import { Outlet } from 'react-router-dom';
 
 const RootLayout = () => {
   return (
-    <main className="mx-auto min-w-1440 max-w-1920 w-full h-screen">
-      <HomeIndicator />
-      <div className="pt-108 h-full">
-        <div className="h-[calc(100vh-108px)]">
+    <main className="mx-auto min-w-1440 max-w-1920 w-full min-h-screen">
+      <div className="min-w-max flex flex-col">
+        <HomeIndicator />
+        <div className="pt-108">
           <Outlet />
         </div>
       </div>

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -1,5 +1,32 @@
+import { useState } from 'react';
+import LifestyleTag from '@/components/Lifestyle/LifeStyleTag';
+
+const TAGS = [
+  'Office/portability',
+  'Developer',
+  'Game',
+  'Study',
+  'Video-editing',
+  'Tour/portability',
+] as const;
+
 const LifestylePage = () => {
-  return <div>LifestylePage</div>;
+  const [selectedLabel, setSelectedLabel] = useState<string>(TAGS[0]);
+
+  return (
+    <div className="h-full w-full flex items-center justify-center">
+      <div className="flex flex-col gap-20 w-fit">
+        {TAGS.map((label) => (
+          <LifestyleTag
+            key={label}
+            label={label}
+            selected={selectedLabel === label}
+            onClick={() => setSelectedLabel(label)}
+          />
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default LifestylePage;

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import LifestyleTag from '@/components/Lifestyle/LifeStyleTag';
+import LifestyleTag from '@/components/Lifestyle/LifestyleTag';
 
 const TAGS = [
   'Office/portability',


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #11 

## 🔍 구현한 내용
- 라이프스타일 태그 공통 컴포넌트를 구현했습니다.
  - `default / hover / pressed` 상태를 하나의 공통 컴포넌트로 처리했습니다.
  - `Tour/portability` 라벨과` Office/portability` 라벨의 경우, pressed 상태에서 / 문자만 자간 10%가 적용되도록 문자열을 분리 렌더링하는 방식으로 구현했습니다.

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/cdac735c-b86d-45cc-9061-85e32cf135a4




## 📢 리뷰어에게
- 현재는 라이프스타일 페이지에 컴포넌트 렌더링만 해둔 상태입니다. 페이지 UI는 추후 단계에서 구현 예정입니다.
- 최종 레이아웃 변경은 없으며, 시도 과정에서 변경되었던 부분들은 원복했습니다. (커밋 메시지는 크게 신경 쓰지 않으셔도 됩니다)