### PR TITLE
feat: 버튼 공통 컴포넌트 구현

### DIFF
--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -1,0 +1,28 @@
+type PrimaryButtonProps = {
+  text: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+const PrimaryButton = ({ text, onClick, disabled = false, className = '' }: PrimaryButtonProps) => {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`
+        flex items-center justify-center
+        h-72
+        rounded-button
+        font-body-2-sm
+        text-white
+        ${className} 
+        ${disabled ? 'bg-gray-300 cursor-not-allowed' : 'cursor-pointer'}
+      `}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default PrimaryButton;

--- a/src/pages/combination/CombinationCreatePage.tsx
+++ b/src/pages/combination/CombinationCreatePage.tsx
@@ -1,26 +1,5 @@
-import PrimaryButton from '@/components/Button/PrimaryButton';
-
 const CombinationCreatePage = () => {
-  return (
-    <div className="flex flex-col gap-10">
-      <PrimaryButton text="로그인" className="w-440" disabled />
-      <PrimaryButton text="로그인" className="w-440 bg-blue-600 hover:bg-blue-500" />
-
-      <PrimaryButton
-        text="로그인하고 내 조합에 담기"
-        className="w-400 bg-blue-500 hover:bg-blue-400"
-      />
-      <PrimaryButton text="내 조합에 담기" className="w-400 bg-blue-500 hover:bg-blue-400" />
-
-      <PrimaryButton text="완료" className="w-280 bg-blue-600 hover:bg-blue-500" />
-      <PrimaryButton text="다음" className="w-280 bg-blue-500 hover:bg-blue-400" />
-
-      <PrimaryButton text="조합1 에 담기" className="w-280 bg-blue-600 hover:bg-blue-500" />
-      <PrimaryButton text="이미 담은 상품입니다." className="w-280" disabled />
-
-      <PrimaryButton text="새 조합 추가하기" className="w-280 bg-blue-600 hover:bg-blue-500" />
-    </div>
-  );
+  return <div>CombinationCreatePage</div>;
 };
 
 export default CombinationCreatePage;

--- a/src/pages/combination/CombinationCreatePage.tsx
+++ b/src/pages/combination/CombinationCreatePage.tsx
@@ -1,5 +1,26 @@
+import PrimaryButton from '@/components/Button/PrimaryButton';
+
 const CombinationCreatePage = () => {
-  return <div>CombinationCreatePage</div>;
+  return (
+    <div className="flex flex-col gap-10">
+      <PrimaryButton text="로그인" className="w-440" disabled />
+      <PrimaryButton text="로그인" className="w-440 bg-blue-600 hover:bg-blue-500" />
+
+      <PrimaryButton
+        text="로그인하고 내 조합에 담기"
+        className="w-400 bg-blue-500 hover:bg-blue-400"
+      />
+      <PrimaryButton text="내 조합에 담기" className="w-400 bg-blue-500 hover:bg-blue-400" />
+
+      <PrimaryButton text="완료" className="w-280 bg-blue-600 hover:bg-blue-500" />
+      <PrimaryButton text="다음" className="w-280 bg-blue-500 hover:bg-blue-400" />
+
+      <PrimaryButton text="조합1 에 담기" className="w-280 bg-blue-600 hover:bg-blue-500" />
+      <PrimaryButton text="이미 담은 상품입니다." className="w-280" disabled />
+
+      <PrimaryButton text="새 조합 추가하기" className="w-280 bg-blue-600 hover:bg-blue-500" />
+    </div>
+  );
 };
 
 export default CombinationCreatePage;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #14 

## 🔍 구현한 내용
- 버튼 공통 컴포넌트 PrimaryButton를 구현했습니다.
- 버튼의 높이, 라운드, 타이포, 기본 레이아웃은 컴포넌트 내부에서 고정하고, 사용하는 곳에서는 가로 길이와 버튼 배경 색상만 지정하도록 구성했습니다.
- 버튼의 hover 색상은 노션 [디자인 시스템 & 에셋] 에 정리된 버튼 컬러 명세를 기준으로 사용처에서 함께 지정하도록 했습니다.
- disabled 상태일 경우, 별도의 색상 지정 없이도 **자동으로 회색 배경(gray-300)과 cursor-not-allowed**가 적용되도록 처리했습니다.
→ 사용처에서는 가로 길이만 지정하면 됩니다.
- 아래는 사용 예시 코드입니다.
  - active
    ```tsx
    <PrimaryButton text="조합1 에 담기" className="w-280 bg-blue-600 hover:bg-blue-500" />
    ```
  - disabled
    ```tsx
    <PrimaryButton text="이미 담은 상품입니다." className="w-280" disabled />
    ```

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/8cf90c89-e0bb-43e3-b811-d5187e81d35a



## 📢 리뷰어에게
- 첨부된 사진 기준으로 연두색 영역에 해당하는 버튼 UI만 공통 컴포넌트로 구현했습니다.
- 간편 회원가입 버튼과 중복 확인 버튼은 로그인 UI 작업 시 선우님께서 함께 구현 예정이라 작업 범위에서는 제외했습니다.
<img width="1311" height="706" alt="스크린샷 2026-01-14 162312" src="https://github.com/user-attachments/assets/256502d5-980e-4970-b41a-5ca794df7517" />

