### PR TITLE
feat: 기기 정보보기 UI 구현

### DIFF
--- a/src/assets/icons/X.svg
+++ b/src/assets/icons/X.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="48" height="48" rx="24" fill="white"/>
+<path d="M15 33L24 24M24 24L33 15M24 24L15 15M24 24L33 33" stroke="#54545F" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Home/HomeIndicator.tsx
+++ b/src/components/Home/HomeIndicator.tsx
@@ -11,7 +11,11 @@ const navTextClass = 'font-body-1-sm text-black hover:text-blue-500 active:text-
 
 type AuthStatus = 'logout' | 'login' | 'guest';
 
-const HomeIndicator = () => {
+interface HomeIndicatorProps {
+  paddingRight?: number;
+}
+
+const HomeIndicator = ({ paddingRight = 0 }: HomeIndicatorProps) => {
   const [authStatus] = useState<AuthStatus>('login');
 
   const navClass = ({ isActive }: { isActive: boolean }) =>
@@ -21,7 +25,10 @@ const HomeIndicator = () => {
     `${brandLinkClass} ${isActive ? 'text-blue-600 hover:text-blue-500' : ''}`;
 
   return (
-    <header className="fixed top-0 left-0 w-full z-50 bg-white h-80">
+    <header
+      className="fixed top-0 left-0 w-full z-50 bg-white h-80"
+      style={{ paddingRight: `${paddingRight}px` }}
+    >
       <div className="mx-auto w-full max-w-1920 h-full">
         <div className="min-w-1440 h-full">
           <div className="flex items-center justify-between h-full pl-44 pr-[clamp(60px,calc(60px+(100vw-1440px)*0.208333),160px)]">

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -413,11 +413,15 @@ const DeviceSearchPage = () => {
 
               {/* Card */}
               <div
-                className="w-1021 bg-white rounded-card px-56 py-40"
+                className="bg-white rounded-card px-56 py-40"
+                style={{ width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)' }}
                 onClick={(e) => e.stopPropagation()}
               >
                 {/* Content */}
-                <div className="flex items-start justify-between gap-100">
+                <div
+                  className="flex items-start justify-between"
+                  style={{ gap: 'clamp(88px, calc(88px + (100vw - 1440px) * 0.245833), 206px)' }}
+                >
                   {/* Left Section */}
                   <div className="w-400 flex flex-col gap-20">
                     {/* Name & Price */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import HomeIndicator from '@/components/Home/HomeIndicator';
 import ProductCard from '@/components/ProductCard/ProductCard';
+import PrimaryButton from '@/components/Button/PrimaryButton';
 import CheckboxIcon from '@/assets/icons/checkbox.svg?react';
 import CheckboxOnIcon from '@/assets/icons/checkbox_on.svg?react';
 import SearchIcon from '@/assets/icons/search.svg?react';
 import DropdownIcon from '@/assets/icons/dropdown.svg?react';
 import FilterIcon from '@/assets/icons/filter.svg?react';
 import TopIcon from '@/assets/icons/top.svg?react';
+import XIcon from '@/assets/icons/X.svg?react';
 
 import {
   DEVICE_CATEGORIES,
@@ -18,6 +21,9 @@ import {
 import { MOCK_PRODUCTS } from '@/constants/mockData';
 
 const DeviceSearchPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedProductId = searchParams.get('productId');
+
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [sortOption, setSortOption] = useState('latest');
@@ -28,11 +34,23 @@ const DeviceSearchPage = () => {
   const [selectedBrand, setSelectedBrand] = useState<string | null>(null);
   const [isAtBottom, setIsAtBottom] = useState(false);
   const [showTopButton, setShowTopButton] = useState(false);
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
 
   const productGridRef = useRef<HTMLDivElement>(null);
   const sortRef = useRef<HTMLDivElement>(null);
   const priceRef = useRef<HTMLDivElement>(null);
   const brandRef = useRef<HTMLDivElement>(null);
+
+  /* 선택된 제품 찾기 */
+  const selectedProduct = selectedProductId
+    ? MOCK_PRODUCTS.find(p => p.id === Number(selectedProductId))
+    : null;
+
+  /* 모달 닫기 */
+  const handleCloseModal = () => {
+    searchParams.delete('productId');
+    setSearchParams(searchParams);
+  };
 
   useEffect(() => {
     const handleScroll = () => {
@@ -78,19 +96,37 @@ const DeviceSearchPage = () => {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  /* 모달 열렸을 때 배경 스크롤 방지 + 레이아웃 시프트 방지 */
+  useEffect(() => {
+    if (selectedProduct) {
+      const width = window.innerWidth - document.documentElement.clientWidth;
+      setScrollbarWidth(width);
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${width}px`;
+    } else {
+      setScrollbarWidth(0);
+      document.body.style.overflow = 'auto';
+      document.body.style.paddingRight = '0px';
+    }
+    return () => {
+      document.body.style.overflow = 'auto';
+      document.body.style.paddingRight = '0px';
+    };
+  }, [selectedProduct]);
+
   const handleScrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
     <div className={`min-h-screen bg-white relative ${isAtBottom ? 'bg-effect-fade-bottom' : ''}`}>
-      <HomeIndicator />
+      <HomeIndicator paddingRight={scrollbarWidth} />
 
       {/* Main Content */}
       {/* <div className="pt-108"> */}
         {/* Search Bar */}
         <div className="flex justify-center pt-156">
-          <div className="w-600 h-72 bg-blue-100 rounded-button px-10 py-20 flex items-center gap-12">
+          <div className="w-600 h-72 bg-blue-100 rounded-button px-12 py-20 flex items-center gap-12">
             <SearchIcon className="w-28 h-28 flex-shrink-0 text-black" />
             <input
               type="text"
@@ -104,7 +140,7 @@ const DeviceSearchPage = () => {
 
         {/* Device Categories */}
         <div className="w-full pt-80">
-          <div className="w-1100 mx-auto 2xl:w-full 2xl:px-[328px] flex items-center justify-between">
+          <div className="w-1100 mx-auto 2xl:w-full 2xl:px-328 flex items-center justify-between">
             {DEVICE_CATEGORIES.map((category) => {
               const { Icon } = category;
               return (
@@ -126,13 +162,13 @@ const DeviceSearchPage = () => {
         </div>
 
         {/* Divider */}
-        <div className="w-full h-10 opacity-50 bg-gradient-to-t from-[#EEEEF0] to-[#E4E4E7] mt-88" />
+        <div className="w-full h-8 opacity-50 bg-gradient-to-t from-[#EEEEF0] to-[#E4E4E7] mt-88" />
 
         {/* Filter Section */}
         <div className="max-w-1600 mx-auto px-160 pt-68">
           
           {/* Filters */}
-          <div className="flex items-center gap-0 pt-10">
+          <div className="flex items-center gap-0 pt-8">
             {/* Filter Icon */}
             <button className="w-48 h-48 flex items-center justify-center">
               <FilterIcon className="w-48 h-48 text-black" />
@@ -142,7 +178,7 @@ const DeviceSearchPage = () => {
             <div ref={priceRef} className="relative flex flex-col gap-16 ml-72">
               <button
                 onClick={() => setShowPriceFilter(!showPriceFilter)}
-                className={`flex items-center justify-center gap-[15px] pl-16 pr-10 py-10 rounded-button cursor-pointer ${
+                className={`flex items-center justify-center gap-16 pl-16 pr-8 py-8 rounded-button cursor-pointer ${
                   selectedPrice
                     ? 'border-2 border-blue-600'
                     : showPriceFilter
@@ -175,7 +211,7 @@ const DeviceSearchPage = () => {
               </button>
 
               {showPriceFilter && (
-                <div className="absolute left-0 top-full mt-6 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-10 flex flex-col gap-16">
+                <div className="absolute left-0 top-full mt-8 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-12 flex flex-col gap-16">
                   {PRICE_OPTIONS.map((option, index) => (
                     <button
                       key={option.value}
@@ -205,7 +241,7 @@ const DeviceSearchPage = () => {
             <div ref={brandRef} className="relative flex flex-col gap-16 ml-32">
               <button
                 onClick={() => setShowBrandFilter(!showBrandFilter)}
-                className={`flex items-center justify-center gap-[15px] pl-16 pr-10 py-10 rounded-button cursor-pointer ${
+                className={`flex items-center justify-center gap-16 pl-16 pr-8 py-8 rounded-button cursor-pointer ${
                   selectedBrand
                     ? 'border-2 border-blue-600'
                     : showBrandFilter
@@ -238,7 +274,7 @@ const DeviceSearchPage = () => {
               </button>
 
               {showBrandFilter && (
-                <div className="absolute left-0 top-full mt-6 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-10 flex flex-col gap-16">
+                <div className="absolute left-0 top-full mt-8 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-10 flex flex-col gap-16">
                   {BRAND_OPTIONS.map((option, index) => (
                     <button
                       key={option.value}
@@ -276,7 +312,7 @@ const DeviceSearchPage = () => {
             <div ref={sortRef} className="relative flex flex-col items-end gap-16">
               <button
                 onClick={() => setShowSortDropdown(!showSortDropdown)}
-                className="flex items-center gap-6 cursor-pointer"
+                className="flex items-center gap-8 cursor-pointer"
               >
                 <p className="font-body-1-sm text-black whitespace-nowrap">
                   {SORT_OPTIONS.find(opt => opt.value === sortOption)?.label}
@@ -291,7 +327,7 @@ const DeviceSearchPage = () => {
               </button>
 
               {showSortDropdown && (
-                <div className="absolute right-0 top-full mt-6 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-10 flex flex-col gap-16">
+                <div className="absolute right-0 top-full mt-8 bg-white rounded-button shadow-[0_2px_10px_rgba(0,0,0,0.25)] p-12 z-12 flex flex-col gap-16">
                   {SORT_OPTIONS.map((option, index) => (
                     <button
                       key={option.value}
@@ -299,7 +335,7 @@ const DeviceSearchPage = () => {
                         setSortOption(option.value);
                         setShowSortDropdown(false);
                       }}
-                      className={`font-body-1-sm text-black text-left pb-10 whitespace-nowrap hover:bg-gray-100 transition-colors ${
+                      className={`font-body-1-sm text-black text-left pb-8 whitespace-nowrap hover:bg-gray-100 transition-colors ${
                         sortOption === option.value
                           ? 'bg-gray-100'
                           : ''
@@ -324,7 +360,14 @@ const DeviceSearchPage = () => {
         <div ref={productGridRef} className="max-w-1600 mx-auto px-160 pt-68">
           <div className="grid grid-cols-4 gap-x-28 gap-y-164">
             {MOCK_PRODUCTS.map((product) => (
-              <ProductCard key={product.id} product={product} />
+              <ProductCard
+                key={product.id}
+                product={product}
+                onClick={() => {
+                  searchParams.set('productId', product.id.toString());
+                  setSearchParams(searchParams);
+                }}
+              />
             ))}
           </div>
         </div>
@@ -343,6 +386,130 @@ const DeviceSearchPage = () => {
         {/* Bottom Spacing */}
         <div className="h-268" />
       {/* </div> */}
+
+      {/* Device Detail Modal */}
+      {selectedProduct && (
+        <>
+          {/* Background Overlay - HomeIndicator(z-50)보다 높게 설정 */}
+          <div
+            className="fixed inset-0 bg-black/50 z-[60]"
+            onClick={handleCloseModal}
+          />
+
+          {/* Modal */}
+          <div
+            className="fixed inset-0 flex justify-center items-center z-[72] pointer-events-none"
+            style={{ paddingRight: `${scrollbarWidth}px` }}
+          >
+            <div className="flex flex-col items-end gap-20 pointer-events-auto">
+              {/* Close Button - 카드 바깥 */}
+              <button
+                onClick={handleCloseModal}
+                className="w-48 h-48 flex items-center justify-center cursor-pointer hover:opacity-80 transition-opacity"
+                aria-label="닫기"
+              >
+                <XIcon className="w-48 h-48 text-white" />
+              </button>
+
+              {/* Card */}
+              <div
+                className="w-1021 bg-white rounded-card px-56 py-40"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* Content */}
+                <div className="flex items-start justify-between gap-100">
+                  {/* Left Section */}
+                  <div className="w-400 flex flex-col gap-20">
+                    {/* Name & Price */}
+                    <div className="flex flex-col gap-12">
+                      <p className="font-heading-1 text-black">{selectedProduct.name}</p>
+                      <div className="flex items-center gap-8 font-heading-2 text-blue-600">
+                        <p>₩</p>
+                        <p>{selectedProduct.price.toLocaleString()}</p>
+                      </div>
+                    </div>
+
+                    {/* Image Section */}
+                    <div className="flex flex-col gap-8">
+                      <div className="w-full h-[360px] bg-gray-200 relative">
+                        {/* Color Chip Dropdown */}
+                        <div className="absolute left-20 top-20 bg-white rounded-button shadow-[0_0_4px_rgba(0,0,0,0.25)] px-8 py-4 flex items-center gap-4">
+                          <div
+                            className="w-40 h-40 rounded-full"
+                            style={{ backgroundColor: selectedProduct.colors[0] }}
+                          />
+                          <DropdownIcon className="w-28 h-14 text-gray-400" />
+                        </div>
+                      </div>
+
+                      {/* Page Control (dots) */}
+                      <div className="flex items-center justify-center gap-24 py-8">
+                        <div className="w-12 h-12 rounded-full bg-black" />
+                        <div className="w-12 h-12 rounded-full bg-gray-300" />
+                        <div className="w-12 h-12 rounded-full bg-gray-300" />
+                      </div>
+                    </div>
+
+                    {/* Button */}
+                    <PrimaryButton
+                      text="로그인하고 내 조합에 담기"
+                      className="w-full bg-blue-500 hover:bg-blue-400 transition-colors"
+                    />
+                  </div>
+
+                  {/* Right Section */}
+                  <div className="w-302 flex flex-col gap-58 pt-127">
+                    {/* Product Info Table */}
+                    <div className="flex flex-col justify-between h-360 pl-16">
+                      <div className="flex items-center gap-80">
+                        <p className="font-body-1-r text-gray-400">모델명</p>
+                        <p className="font-body-1-r text-black">{selectedProduct.name}</p>
+                      </div>
+                      <div className="flex items-center gap-58">
+                        <p className="font-body-1-r text-gray-400">카테고리</p>
+                        <p className="font-body-1-r text-black">{selectedProduct.category}</p>
+                      </div>
+                      <div className="flex items-center gap-78">
+                        <p className="font-body-1-r text-gray-400">브랜드</p>
+                        <p className="font-body-1-r text-black">Apple</p>
+                      </div>
+                      <div className="flex items-center gap-100">
+                        <p className="font-body-1-r text-gray-400">색상</p>
+                        <p className="font-body-1-r text-black">내추럴 티타늄</p>
+                      </div>
+                      <div className="flex items-center gap-100">
+                        <p className="font-body-1-r text-gray-400">가격</p>
+                        <div className="flex items-center gap-4 font-body-1-r text-black">
+                          <p>{selectedProduct.price.toLocaleString()}</p>
+                          <p>원</p>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-56">
+                        <p className="font-body-1-r text-gray-400">충전방식</p>
+                        <p className="font-body-1-r text-black">USB-C</p>
+                      </div>
+                      <div className="flex items-center gap-80">
+                        <p className="font-body-1-r text-gray-400">출시일</p>
+                        <p className="font-body-1-r text-black">2023년 9월</p>
+                      </div>
+                    </div>
+
+                    {/* Hashtags */}
+                    <div className="flex items-center gap-16">
+                      <div className="bg-blue-100 rounded-tag px-20 py-8">
+                        <p className="font-body-1-r text-black">#office</p>
+                      </div>
+                      <div className="bg-blue-100 rounded-tag px-20 py-8">
+                        <p className="font-body-1-r text-black">#portability</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #18

## 🔍 구현한 내용

기기 상세 정보 모달 UI를 구현했습니다.

- 기기 검색 페이지에서 제품 카드 클릭 시 상세 정보 모달이 표시됩니다.
- 모달 열릴 때 스크롤바 사라짐으로 인한 레이아웃 시프트를 방지했습니다. (body, HomeIndicator,  모달 컨테이너 모두 보정)
- 공용 컴포넌트인 PrimaryButton을 활용하여 "로그인하고 내 조합에 담기" 버튼을 구현했습니다. 
- 기존에 맞지 않던 상수들 4의 배수로 수정하였습니다.
- 그 외 자잘한 css 수정 했습니다. 

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/4ee9707e-ba99-422f-8b5e-21912ae5c1f2


## 📢 리뷰어에게

- 모달 내 제품 정보는 현재 mock 데이터를 사용하고 있으며, 추후 API 연동 예정입니다.
- HomeIndicator에 paddingRight prop을 추가했습니다. 모달이 열릴 때만 전달되며, 다른 페이지에서 는 기존처럼 prop 없이 사용하면 됩니다.



