### PR TITLE
feat: 조합도 태그 컴포넌트 구현

### DIFF
--- a/src/components/Combintaion/CombinationTag.tsx
+++ b/src/components/Combintaion/CombinationTag.tsx
@@ -1,0 +1,41 @@
+import { type CombinationName, type CombinationStatus } from '@/constants/combination';
+
+type CombinationTagProps = {
+  name: CombinationName;
+  status: CombinationStatus;
+  className?: string;
+};
+
+const NAME_STYLE_MAP: Record<CombinationName, string> = {
+  연동성: 'bg-blue-200 text-blue-700',
+  편의성: 'bg-light-green text-dark-green',
+  라이프스타일: 'bg-light-yellow text-dark-yellow',
+  '컬러 매칭': 'bg-light-purple text-dark-purple',
+};
+
+const STATUS_STYLE_MAP: Record<CombinationStatus, string> = {
+  최적: 'font-caption-sm text-optimal',
+  보통: 'font-caption-sm text-normal',
+  미흡: 'font-caption-sm text-poor',
+  '-': 'font-caption-sm text-optimal',
+};
+
+const CombinationTag = ({ name, status, className = '' }: CombinationTagProps) => {
+  return (
+    <span
+      className={`
+        inline-flex items-center gap-8
+        px-12 py-8 h-30
+        rounded-tag
+        font-caption-r
+        ${NAME_STYLE_MAP[name]}
+        ${className}
+      `}
+    >
+      <span>{name}:</span>
+      <span className={STATUS_STYLE_MAP[status]}>{status}</span>
+    </span>
+  );
+};
+
+export default CombinationTag;

--- a/src/constants/combination.ts
+++ b/src/constants/combination.ts
@@ -1,0 +1,5 @@
+export const COMBINATION_NAMES = ['연동성', '편의성', '라이프스타일', '컬러 매칭'] as const;
+export const COMBINATION_STATUSES = ['최적', '보통', '미흡', '-'] as const;
+
+export type CombinationName = (typeof COMBINATION_NAMES)[number];
+export type CombinationStatus = (typeof COMBINATION_STATUSES)[number];


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #20 

## 🔍 구현한 내용
- CombinationTag는 **name / status 값만 전달하면 사용할 수 있도록 구현**했습니다.
  - name 값에 따라 배경색 / 텍스트 컬러가 자동으로 매핑되며, status 값에 따라 상태별 텍스트 스타일이 자동 적용됩니다.
  - 사용 시 컬러나 폰트 클래스를 별도로 지정할 필요가 없도록 공통 컴포넌트로 구성했습니다.
  - 사용 예시
    ```tsx
    <CombinationTag name="연동성" status="최적" />
    <CombinationTag name="편의성" status="보통" />
    <CombinationTag name="라이프스타일" status="미흡" />
    <CombinationTag name="컬러 매칭" status="-" />
    ```

## 📸 스크린샷 or 실행 영상
<img width="647" height="257" alt="스크린샷 2026-01-15 234005" src="https://github.com/user-attachments/assets/e8c2111e-0c90-4483-90ef-23b3d00ceab7" />


## 📢 리뷰어에게
