### PR TITLE
feat: 마이페이지 설정 UI 구현

### DIFF
--- a/src/assets/icons/chevron_right.svg
+++ b/src/assets/icons/chevron_right.svg
@@ -1,0 +1,3 @@
+<svg width="21" height="38" viewBox="0 0 21 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.75 0.75L19.9241 18.0067C20.3655 18.4039 20.3655 19.0961 19.9241 19.4933L0.75 36.75" stroke="#54545F" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/Setting/SettingRow.tsx
+++ b/src/components/Setting/SettingRow.tsx
@@ -1,0 +1,34 @@
+import ChevronRightIcon from '@/assets/icons/chevron_right.svg?react';
+
+interface SettingRowProps {
+  title: string;
+  onClick?: () => void;
+}
+
+const SettingRow = ({ title, onClick }: SettingRowProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        flex
+        w-full
+        h-90
+        items-center
+        justify-between
+        px-60
+        pl-28
+        rounded-card
+        bg-white
+        hover:bg-gray-100
+        border-shadow-deep-black
+        cursor-pointer
+      "
+    >
+      <span className="font-body-1-sm text-black">{title}</span>
+      <ChevronRightIcon className="w-20 h-36" />
+    </button>
+  );
+};
+
+export default SettingRow;

--- a/src/components/Setting/SettingRow.tsx
+++ b/src/components/Setting/SettingRow.tsx
@@ -1,4 +1,4 @@
-import ChevronRightIcon from '@/assets/icons/chevron_right.svg?react';
+import ChevronRight from '@/assets/icons/chevron_right.svg?react';
 
 interface SettingRowProps {
   title: string;
@@ -26,7 +26,7 @@ const SettingRow = ({ title, onClick }: SettingRowProps) => {
       "
     >
       <span className="font-body-1-sm text-black">{title}</span>
-      <ChevronRightIcon className="w-20 h-36" />
+      <ChevronRight className="w-20 h-36" />
     </button>
   );
 };

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -36,6 +36,7 @@ export const ROUTES = {
     combinationDetail: (id: string) => `/my/combinations/${id}`,
     // navigate(ROUTES.my.combinationDetail(id)); 이런식으로 사용 가능
     settings: {
+      base: '/my/settings',
       profile: '/my/settings/profile',
       password: '/my/settings/password',
     },

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,10 @@
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.25);
   }
 
+  .border-shadow-deep-black {
+    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.5);
+  }
+
   .border-shadow-gray {
     box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.1);
   }

--- a/src/pages/my/settings/SettingPage.tsx
+++ b/src/pages/my/settings/SettingPage.tsx
@@ -1,0 +1,5 @@
+const SettingPage = () => {
+  return <div>SettingPage</div>;
+};
+
+export default SettingPage;

--- a/src/pages/my/settings/SettingPage.tsx
+++ b/src/pages/my/settings/SettingPage.tsx
@@ -1,5 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+import SettingRow from '@/components/Setting/SettingRow';
+
 const SettingPage = () => {
-  return <div>SettingPage</div>;
+  const navigate = useNavigate();
+
+  return (
+    <div className="px-160 mt-92 flex flex-col gap-32">
+      <p className="font-heading-2 text-black">설정</p>
+      <div className="flex flex-col gap-8">
+        <SettingRow title="프로필 수정" onClick={() => navigate('/my/settings/profile')} />
+        <SettingRow title="공지사항" onClick={() => navigate('/support/notices')} />
+        <SettingRow
+          title="고객센터/문의하기"
+          onClick={() => navigate('/support/customer-center')}
+        />
+        <SettingRow title="서비스 이용약관" onClick={() => navigate('/support/terms')} />
+        <SettingRow title="개인정보 처리방침" onClick={() => navigate('/support/privacy-policy')} />
+      </div>
+    </div>
+  );
 };
 
 export default SettingPage;

--- a/src/pages/my/settings/SettingPage.tsx
+++ b/src/pages/my/settings/SettingPage.tsx
@@ -5,17 +5,22 @@ const SettingPage = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="px-160 mt-92 flex flex-col gap-32">
-      <p className="font-heading-2 text-black">설정</p>
-      <div className="flex flex-col gap-8">
-        <SettingRow title="프로필 수정" onClick={() => navigate('/my/settings/profile')} />
-        <SettingRow title="공지사항" onClick={() => navigate('/support/notices')} />
-        <SettingRow
-          title="고객센터/문의하기"
-          onClick={() => navigate('/support/customer-center')}
-        />
-        <SettingRow title="서비스 이용약관" onClick={() => navigate('/support/terms')} />
-        <SettingRow title="개인정보 처리방침" onClick={() => navigate('/support/privacy-policy')} />
+    <div className="min-h-[calc(100vh-80px)] flex items-center">
+      <div className="w-full px-160 flex flex-col gap-32">
+        <p className="font-heading-2 text-black">설정</p>
+        <div className="flex flex-col gap-8">
+          <SettingRow title="프로필 수정" onClick={() => navigate('/my/settings/profile')} />
+          <SettingRow title="공지사항" onClick={() => navigate('/support/notices')} />
+          <SettingRow
+            title="고객센터/문의하기"
+            onClick={() => navigate('/support/customer-center')}
+          />
+          <SettingRow title="서비스 이용약관" onClick={() => navigate('/support/terms')} />
+          <SettingRow
+            title="개인정보 처리방침"
+            onClick={() => navigate('/support/privacy-policy')}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -17,6 +17,7 @@ import CombinationCreatePage from '@/pages/combination/CombinationCreatePage';
 // my
 import MyPage from '@/pages/my/MyPage';
 import MyCombinationDetailPage from '@/pages/my/MyCombinationDetailPage';
+import MySettingsPage from '@/pages/my/settings/SettingPage';
 import MySettingsProfilePage from '@/pages/my/settings/ProfileEditPage';
 import MySettingsPasswordPage from '@/pages/my/settings/PasswordEditPage';
 import MyTrashPage from '@/pages/my/MyTrashPage';
@@ -65,6 +66,7 @@ export const AppRoutes = [
           {
             path: 'settings',
             children: [
+              { index: true, element: <MySettingsPage /> },
               { path: 'profile', element: <MySettingsProfilePage /> },
               { path: 'password', element: <MySettingsPasswordPage /> },
             ],


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #32 

## 🔍 구현한 내용
- 마이페이지 > 설정 페이지(/my/settings)를 구현했습니다.
- 설정 리스트 아이템 컴포넌트(SettingRow)를 생성했습니다.
- 각 설정 컴포넌트 클릭 시 해당 페이지로 이동하도록 라우팅을 연결했습니다.

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/16a74fcf-a266-4973-ac73-e3d31cd1907b



## 📢 리뷰어에게
