### PR TITLE
feat: 아이디 및 비밀번호 찾기 페이지 UI 및 유효성 검증

### DIFF
--- a/src/components/Input/PrimaryInput.tsx
+++ b/src/components/Input/PrimaryInput.tsx
@@ -12,7 +12,7 @@ const PrimaryInput = forwardRef<HTMLInputElement, PrimaryInputProps>(
         type={type}
         disabled={disabled}
         className={`
-          w-full px-16 py-24 bg-white border border-black rounded-button
+          w-full h-72 px-16 py-24 bg-white border border-black rounded-button
           font-body-2-r text-gray-500 placeholder:text-gray-300
           outline-none focus:border-blue-500
           ${disabled ? 'bg-gray-100 cursor-not-allowed' : ''}

--- a/src/pages/auth/FindIdPage.tsx
+++ b/src/pages/auth/FindIdPage.tsx
@@ -14,10 +14,10 @@ const FindIdPage = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors, isSubmitted },
   } = useForm<FindIdFormData>({
     resolver: zodResolver(findIdSchema),
-    mode: 'onChange',
+    mode: 'onSubmit', // 제출 시에만 검사
   });
 
   // 아이디 찾기 제출 핸들러
@@ -31,7 +31,7 @@ const FindIdPage = () => {
       {/* 전체 컨테이너 */}
       <div className="flex flex-col items-center gap-20">
         {/* 메인 폼 영역 */}
-        <div className="flex flex-col items-center gap-56">
+        <div className="flex flex-col items-center gap-28">
           {/* 로고 */}
           <p className="font-service-name text-black">Device Life</p>
 
@@ -41,34 +41,28 @@ const FindIdPage = () => {
             className="flex flex-col items-center gap-24 w-400"
           >
             {/* 입력 + 버튼 영역 */}
-            <div className="flex flex-col gap-20 w-full">
+            <div className="flex flex-col w-full">
               {/* 입력창들 */}
-              <div className="flex flex-col gap-8">
-                <div className="flex flex-col gap-4">
-                  <PrimaryInput {...register('name')} type="text" placeholder="이름" />
-                  {errors.name && (
-                    <p className="font-body-3-r text-warning">{errors.name.message}</p>
-                  )}
-                </div>
-                <div className="flex flex-col gap-4">
+              <div className="relative flex flex-col gap-8 mb-56">
+                <PrimaryInput {...register('name')} type="text" placeholder="이름" />
+                <div className="relative">
                   <PrimaryInput
                     {...register('phone')}
                     type="tel"
                     placeholder="휴대폰 번호"
                     maxLength={11}
                   />
-                  {errors.phone && (
-                    <p className="font-body-3-r text-warning">{errors.phone.message}</p>
+                  {/* 에러 메시지 - 휴대폰 번호 입력창 바로 아래 gap-8 (첫 번째 에러만, absolute) */}
+                  {isSubmitted && (errors.name || errors.phone) && (
+                    <p className="absolute top-full mt-8 left-0 font-body-3-r text-warning">
+                      {errors.name?.message || errors.phone?.message}
+                    </p>
                   )}
                 </div>
               </div>
 
               {/* 아이디 찾기 버튼 */}
-              <PrimaryButton
-                text="아이디 찾기"
-                className="w-full bg-blue-600"
-                disabled={!isValid}
-              />
+              <PrimaryButton text="아이디 찾기" className="w-full bg-blue-600" />
             </div>
 
             {/* 아이디/비밀번호 찾기 */}

--- a/src/pages/auth/FindIdPage.tsx
+++ b/src/pages/auth/FindIdPage.tsx
@@ -31,7 +31,7 @@ const FindIdPage = () => {
       {/* 전체 컨테이너 */}
       <div className="flex flex-col items-center gap-20">
         {/* 메인 폼 영역 */}
-        <div className="flex flex-col items-center gap-28">
+        <div className="flex flex-col items-center gap-56">
           {/* 로고 */}
           <p className="font-service-name text-black">Device Life</p>
 
@@ -54,7 +54,7 @@ const FindIdPage = () => {
                   <PrimaryInput
                     {...register('phone')}
                     type="tel"
-                    placeholder="휴대폰 번호 (- 없이 입력)"
+                    placeholder="휴대폰 번호"
                     maxLength={11}
                   />
                   {errors.phone && (

--- a/src/pages/auth/FindIdPage.tsx
+++ b/src/pages/auth/FindIdPage.tsx
@@ -44,7 +44,12 @@ const FindIdPage = () => {
             <div className="flex flex-col gap-20 w-full">
               {/* 입력창들 */}
               <div className="flex flex-col gap-8">
-                <PrimaryInput {...register('name')} type="text" placeholder="이름" />
+                <div className="flex flex-col gap-4">
+                  <PrimaryInput {...register('name')} type="text" placeholder="이름" />
+                  {errors.name && (
+                    <p className="font-body-3-r text-warning">{errors.name.message}</p>
+                  )}
+                </div>
                 <div className="flex flex-col gap-4">
                   <PrimaryInput
                     {...register('phone')}

--- a/src/pages/auth/FindIdPage.tsx
+++ b/src/pages/auth/FindIdPage.tsx
@@ -1,5 +1,116 @@
+import PrimaryButton from '@/components/Button/PrimaryButton';
+import PrimaryInput from '@/components/Input/PrimaryInput';
+import { ROUTES } from '@/constants/routes';
+import { useNavigate } from 'react-router-dom';
+import GoogleLogo from '@/assets/logos/google.svg?react';
+import AppleLogo from '@/assets/logos/apple.svg?react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { findIdSchema, type FindIdFormData } from '@/schemas/authSchema';
+
 const FindIdPage = () => {
-  return <div>FindIdPage</div>;
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FindIdFormData>({
+    resolver: zodResolver(findIdSchema),
+    mode: 'onChange',
+  });
+
+  // 아이디 찾기 제출 핸들러
+  const onSubmit = (data: FindIdFormData) => {
+    // TODO: 아이디 찾기 API 호출
+    console.log(data);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-80px)]">
+      {/* 전체 컨테이너 */}
+      <div className="flex flex-col items-center gap-20">
+        {/* 메인 폼 영역 */}
+        <div className="flex flex-col items-center gap-28">
+          {/* 로고 */}
+          <p className="font-service-name text-black">Device Life</p>
+
+          {/* 폼 컨테이너 */}
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col items-center gap-24 w-400"
+          >
+            {/* 입력 + 버튼 영역 */}
+            <div className="flex flex-col gap-20 w-full">
+              {/* 입력창들 */}
+              <div className="flex flex-col gap-8">
+                <PrimaryInput {...register('name')} type="text" placeholder="이름" />
+                <div className="flex flex-col gap-4">
+                  <PrimaryInput
+                    {...register('phone')}
+                    type="tel"
+                    placeholder="휴대폰 번호 (- 없이 입력)"
+                    maxLength={11}
+                  />
+                  {errors.phone && (
+                    <p className="font-body-3-r text-warning">{errors.phone.message}</p>
+                  )}
+                </div>
+              </div>
+
+              {/* 아이디 찾기 버튼 */}
+              <PrimaryButton
+                text="아이디 찾기"
+                className="w-full bg-blue-600"
+                disabled={!isValid}
+              />
+            </div>
+
+            {/* 아이디/비밀번호 찾기 */}
+            <div className="flex items-center gap-16 font-body-2-r text-gray-400">
+              <button
+                type="button"
+                className="cursor-pointer"
+                onClick={() => navigate(ROUTES.auth.findId)}
+              >
+                아이디 찾기
+              </button>
+              <span>|</span>
+              <button
+                type="button"
+                className="cursor-pointer"
+                onClick={() => navigate(ROUTES.auth.findPassword)}
+              >
+                비밀번호 찾기
+              </button>
+            </div>
+          </form>
+        </div>
+
+        {/* 소셜 로그인 */}
+        <div className="flex items-center gap-40">
+          <button type="button" className="cursor-pointer">
+            <GoogleLogo className="size-50" />
+          </button>
+          <button type="button" className="cursor-pointer">
+            <AppleLogo className="size-50" />
+          </button>
+        </div>
+
+        {/* 회원가입 안내 */}
+        <div className="flex items-center gap-16 font-body-2-r text-gray-400">
+          <span>아직 Device Life 회원이 아니신가요?</span>
+          <button
+            type="button"
+            className="underline underline-offset-4 cursor-pointer"
+            onClick={() => navigate(ROUTES.auth.signup)}
+          >
+            회원가입 하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default FindIdPage;

--- a/src/pages/auth/FindPasswordPage.tsx
+++ b/src/pages/auth/FindPasswordPage.tsx
@@ -31,7 +31,7 @@ const FindPasswordPage = () => {
       {/* 전체 컨테이너 */}
       <div className="flex flex-col items-center gap-20">
         {/* 메인 폼 영역 */}
-        <div className="flex flex-col items-center gap-28">
+        <div className="flex flex-col items-center gap-56">
           {/* 로고 */}
           <p className="font-service-name text-black">Device Life</p>
 
@@ -44,7 +44,7 @@ const FindPasswordPage = () => {
             <div className="flex flex-col gap-20 w-full">
               {/* 입력창들 */}
               <div className="flex flex-col gap-8">
-                <PrimaryInput {...register('email')} type="email" placeholder="이메일" />
+                <PrimaryInput {...register('email')} type="email" placeholder="이메일(ID)" />
               </div>
               {/* 인증번호 받기 버튼 */}
               <PrimaryButton

--- a/src/pages/auth/FindPasswordPage.tsx
+++ b/src/pages/auth/FindPasswordPage.tsx
@@ -14,10 +14,10 @@ const FindPasswordPage = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors, isSubmitted },
   } = useForm<FindPasswordFormData>({
     resolver: zodResolver(findPasswordSchema),
-    mode: 'onChange',
+    mode: 'onSubmit', // 제출 시에만 검사
   });
 
   // 인증번호 받기 제출 핸들러
@@ -38,6 +38,7 @@ const FindPasswordPage = () => {
           {/* 폼 컨테이너 */}
           <form
             onSubmit={handleSubmit(onSubmit)}
+            noValidate
             className="flex flex-col items-center gap-24 w-400"
           >
             {/* 입력 + 버튼 영역 */}
@@ -45,13 +46,13 @@ const FindPasswordPage = () => {
               {/* 입력창들 */}
               <div className="flex flex-col gap-8">
                 <PrimaryInput {...register('email')} type="email" placeholder="이메일(ID)" />
+                {/* 에러 메시지 - 제출 시에만 표시 */}
+                {isSubmitted && errors.email && (
+                  <p className="font-body-3-r text-warning">{errors.email.message}</p>
+                )}
               </div>
               {/* 인증번호 받기 버튼 */}
-              <PrimaryButton
-                text="인증번호 받기"
-                className="w-full bg-blue-600"
-                disabled={!isValid}
-              />
+              <PrimaryButton text="인증번호 받기" className="w-full bg-blue-600" />
             </div>
 
             {/* 아이디/비밀번호 찾기 */}

--- a/src/pages/auth/FindPasswordPage.tsx
+++ b/src/pages/auth/FindPasswordPage.tsx
@@ -1,5 +1,104 @@
+import PrimaryButton from '@/components/Button/PrimaryButton';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants/routes';
+import GoogleLogo from '@/assets/logos/google.svg?react';
+import AppleLogo from '@/assets/logos/apple.svg?react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { findPasswordSchema, type FindPasswordFormData } from '@/schemas/authSchema';
+import PrimaryInput from '@/components/Input/PrimaryInput';
+
 const FindPasswordPage = () => {
-  return <div>FindPasswordPage</div>;
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FindPasswordFormData>({
+    resolver: zodResolver(findPasswordSchema),
+    mode: 'onChange',
+  });
+
+  // 인증번호 받기 제출 핸들러
+  const onSubmit = (data: FindPasswordFormData) => {
+    // TODO: 인증번호 받기 API 호출
+    console.log(data);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-80px)]">
+      {/* 전체 컨테이너 */}
+      <div className="flex flex-col items-center gap-20">
+        {/* 메인 폼 영역 */}
+        <div className="flex flex-col items-center gap-28">
+          {/* 로고 */}
+          <p className="font-service-name text-black">Device Life</p>
+
+          {/* 폼 컨테이너 */}
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col items-center gap-24 w-400"
+          >
+            {/* 입력 + 버튼 영역 */}
+            <div className="flex flex-col gap-20 w-full">
+              {/* 입력창들 */}
+              <div className="flex flex-col gap-8">
+                <PrimaryInput {...register('email')} type="email" placeholder="이메일" />
+              </div>
+              {/* 인증번호 받기 버튼 */}
+              <PrimaryButton
+                text="인증번호 받기"
+                className="w-full bg-blue-600"
+                disabled={!isValid}
+              />
+            </div>
+
+            {/* 아이디/비밀번호 찾기 */}
+            <div className="flex items-center gap-16 font-body-2-r text-gray-400">
+              <button
+                type="button"
+                className="cursor-pointer"
+                onClick={() => navigate(ROUTES.auth.findId)}
+              >
+                아이디 찾기
+              </button>
+              <span>|</span>
+              <button
+                type="button"
+                className="cursor-pointer"
+                onClick={() => navigate(ROUTES.auth.findPassword)}
+              >
+                비밀번호 찾기
+              </button>
+            </div>
+          </form>
+        </div>
+
+        {/* 소셜 로그인 */}
+        <div className="flex items-center gap-40">
+          <button type="button" className="cursor-pointer">
+            <GoogleLogo className="size-50" />
+          </button>
+          <button type="button" className="cursor-pointer">
+            <AppleLogo className="size-50" />
+          </button>
+        </div>
+
+        {/* 회원가입 안내 */}
+        <div className="flex items-center gap-16 font-body-2-r text-gray-400">
+          <span>아직 Device Life 회원이 아니신가요?</span>
+          <button
+            type="button"
+            className="underline underline-offset-4 cursor-pointer"
+            onClick={() => navigate(ROUTES.auth.signup)}
+          >
+            회원가입 하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default FindPasswordPage;

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -30,3 +30,10 @@ export const findIdSchema = z.object({
 });
 
 export type FindIdFormData = z.infer<typeof findIdSchema>;
+
+// 비밀번호 찾기 스키마
+export const findPasswordSchema = z.object({
+  email: emailSchema,
+});
+
+export type FindPasswordFormData = z.infer<typeof findPasswordSchema>;

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -24,9 +24,10 @@ export const findIdSchema = z.object({
   phone: z
     .string()
     .min(1, '휴대폰 번호를 입력해주세요')
-    .regex(/^[0-9]+$/, '숫자만 입력해주세요')
-    .min(10, '휴대폰 번호는 10자리 이상이어야 합니다')
-    .max(11, '휴대폰 번호는 11자리 이하여야 합니다'),
+    .refine(
+      (value) => /^[0-9]+$/.test(value) && value.length >= 10 && value.length <= 11,
+      '휴대폰 번호 형식을 확인해주세요'
+    ),
 });
 
 export type FindIdFormData = z.infer<typeof findIdSchema>;

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -17,3 +17,16 @@ export const loginSchema = z.object({
 });
 
 export type LoginFormData = z.infer<typeof loginSchema>;
+
+// 아이디 찾기 스키마
+export const findIdSchema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요'),
+  phone: z
+    .string()
+    .min(1, '휴대폰 번호를 입력해주세요')
+    .regex(/^[0-9]+$/, '숫자만 입력해주세요')
+    .min(10, '휴대폰 번호는 10자리 이상이어야 합니다')
+    .max(11, '휴대폰 번호는 11자리 이하여야 합니다'),
+});
+
+export type FindIdFormData = z.infer<typeof findIdSchema>;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #28 

## 🔍 구현한 내용
- 아이디 찾기 페이지의 전체적인 UI를 구현했습니다.
- 비밀번호 찾기 페이지의 전체적인 UI를 구현했습니다.
- 유효성 검사를 통해 버튼이 활성/비활성화 되게 하였습니다.
  - 아이디 찾기
    - 이름: 빈 값 체크: 최소 1자 이상
    - 휴대폰 번호(- 없이 입력): 빈 값 체크, 숫자만 허용, 길이 10 ~ 11자리
   - 비밀번호 찾기
     - 이메일: 이메일 형식 검증
- 아래 필드는 요건을 만족 못하는 경우 에러 메시지가 뜨게 하였습니다.
  - 이름: "이름을 입력해주세요"
  - 휴대폰: " "휴대폰 번호를 입력해주세요" / "숫자만 입력해주세요" / "휴대폰 번호는 10자리 이상이어야 합니다" / "휴대폰 번호는 11자리 이하여야 합니다"


## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/32e2c109-855c-4af4-aba6-bc137e63068b


## 📢 리뷰어에게
