### PR TITLE
feat: 라이프스타일 태그 공통 컴포넌트(rounded) 구현 및 사용 방식 분리

### DIFF
--- a/src/components/Lifestyle/RoundedLifestyleTag.tsx
+++ b/src/components/Lifestyle/RoundedLifestyleTag.tsx
@@ -1,0 +1,42 @@
+type RoundedLifestyleTagProps =
+  | { label: string }
+  | {
+      label: string;
+      selected: boolean;
+      onToggle: (label: string, nextSelected: boolean) => void;
+    };
+
+const RoundedLifestyleTag = (props: RoundedLifestyleTagProps) => {
+  const isInteractive = 'onToggle' in props;
+
+  const handleClick = () => {
+    if (!isInteractive) return;
+    props.onToggle(props.label, !props.selected);
+  };
+
+  const opacityClass = isInteractive
+    ? props.selected
+      ? 'opacity-100'
+      : 'opacity-50'
+    : 'opacity-100';
+  const cursorClass = isInteractive ? 'cursor-pointer' : 'cursor-default';
+
+  return (
+    <div
+      onClick={handleClick}
+      className={`
+        inline-flex items-center justify-center gap-8
+        px-12 py-8 rounded-tag
+        bg-gray-100
+        font-body-3-sm text-blue-600
+        transition-opacity
+        ${opacityClass}
+        ${cursorClass}
+      `}
+    >
+      # {props.label}
+    </div>
+  );
+};
+
+export default RoundedLifestyleTag;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #34 

## 🔍 구현한 내용
### 1. **표시용 사용 (마이페이지 등)**

- 라이프스타일 태그를 선택 로직 없이 단순 **표시용**으로 사용합니다.
- 항상 불투명한 상태로 렌더링되며, 클릭 이벤트는 없습니다.
- 마이페이지와 같이 이미 선택된 결과를 보여주는 화면에서 사용합니다.
    ```tsx
    <RoundedLifestyleTag label="Office" />
    ```

### 2. **선택/해제용 사용 (프로필 수정 페이지 등)**

- 라이프스타일 태그를 클릭하여 **선택 / 해제**할 수 있습니다.
- 기본 상태는 반투명이며, 클릭 시 선택된 태그는 불투명으로 표시됩니다.
- 선택 상태는 부모 컴포넌트에서 관리하며, 추후 프로필 수정 페이지에서 선택된 태그만 모아 저장하기 버튼 클릭 시 서버로 전송할 request body에 포함하도록 설계했습니다.
   ```tsx
    // onToggle 로직 중략
    <RoundedLifestyleTag
      label="Office"
      selected={lifestyleList.includes('Office')}
      onToggle={onToggle}
    />
   ```


## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/dffbea58-717e-46f8-a9db-ea82ce68e14f



## 📢 리뷰어에게
- 마이페이지에서는 클릭이 없는 표시용 태그(항상 불투명), 프로필 수정 페이지에서는 기본 미선택(반투명) 상태에서 선택/해제가 가능한 태그로 사용하는 것이 UX적으로 자연스럽다고 판단해 라이프스타일 태그의 사용 방식을 표시용 / 선택용으로 분리했습니다. 혹시 더 나은 설계나 사용 방식에 대한 의견이 있다면 코멘트 부탁드립니다!
