### PR TITLE
deploy: 배포 스크립트 작성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['develop']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: waldls
+          destination-repository-name: DeviceLife_Frontend
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: develop
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+cd ../
+mkdir output
+cp -R ./Frontend/* ./output
+cp -R ./output ./Frontend/


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #40 

## 🔍 구현한 내용
- GitHub Actions를 통해 develop 브랜치 푸시 시 자동으로 빌드 및 배포가 진행되도록 설정했습니다.
- build.sh 스크립트를 추가하여 Frontend 결과물을 output 디렉토리로 생성하도록 구성했습니다.
- 생성된 output 디렉토리를 포크한 레포지토리(DeviceLife_Frontend)의 develop 브랜치로 자동 푸시하도록 워크플로우를 구현했습니다.

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
- 테스트를 위해 우선 바로 merge 합니다.