### PR TITLE
deploy: 배포 pr 미리보기 기능 설정

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,43 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: ['develop']
+
+jobs:
+  vercel-preview:
+    runs-on: ubuntu-latest
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest && npm install --global pnpm
+      - name: Get Vercel Environment Variables
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+
+        run: |
+
+          vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > vercel-output.txt
+          echo "preview_url=$(cat vercel-output.txt)" >> $GITHUB_OUTPUT
+
+      - name: Comment PR with Preview URL
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ✅ PREVIEW ${{ steps.deploy.outputs.preview_url }}
+
+permissions:
+  contents: read
+  pages: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.vercel
+.env*.local


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #42 

## 🔍 구현한 내용
- develop 브랜치 대상 Pull Request 생성 시 Vercel Preview 배포가 자동으로 실행되도록 GitHub Actions 워크플로우를 추가했습니다.
- Vercel CLI를 사용해 preview 환경 변수(vercel pull)를 자동으로 가져오고, 빌드 및 배포를 수행하도록 구성했습니다.
- 배포 완료 후 생성된 Preview URL을 PR 댓글로 자동 등록하여 리뷰 시 바로 확인할 수 있도록 했습니다.

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
- 테스트를 위해 우선 바로 merge 합니다.
