### PR TITLE
Design: 기기검색 Flow, 마이페이지 UI 수정

### DIFF
--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -68,7 +68,7 @@ const CombinationDeviceCard = ({
       </div>
 
       {/* 기기 그리드 */}
-      <div className="pl-8 relative">
+      <div className="pl-8 mt-24 relative">
         <div className={`grid ${gridColsClass} gap-x-28 gap-y-12`}>
           {displayedDevices.map((device) => (
             <div

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -44,8 +44,8 @@ const CombinationDeviceCard = ({
   };
 
   const gridColsClass = columns === 4 ? 'grid-cols-4' : 'grid-cols-3';
-  const deviceCardWidth = columns === 4 ? 'w-255' : 'w-244';
-  const deviceImageSize = columns === 4 ? 'w-100 h-100' : 'w-64 h-64';
+  const deviceCardWidth = columns === 4 ? 'w-244' : 'w-244';
+  const deviceImageSize = columns === 4 ? 'w-64 h-64' : 'w-64 h-64';
 
   return (
     <div className={className}>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -28,7 +28,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
         </p>
 
         {/* Color Chips */}
-        <div className="flex gap-8">
+        {/* <div className="flex gap-8">
           {product.colors.map((color, idx) => (
             <div
               key={idx}
@@ -36,7 +36,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
               style={{ backgroundColor: color }}
             />
           ))}
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -509,7 +509,9 @@ const DeviceSearchPage = () => {
                   className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] flex flex-col"
                   style={{
                     width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)',
-                    height: showAllDevices ? '730px' : '697px',
+                    height: showAllDevices
+                      ? 'clamp(700px, calc(700px + (100vw - 1440px) * 0.0625), 730px)'
+                      : '697px',
                     transition: 'height 0.3s ease',
                   }}
                   onClick={(e) => e.stopPropagation()}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -506,7 +506,7 @@ const DeviceSearchPage = () => {
 
                 {/* Card */}
                 <div
-                  className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] flex flex-col"
+                  className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] relative"
                   style={{
                     width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)',
                     height: showAllDevices
@@ -526,11 +526,11 @@ const DeviceSearchPage = () => {
                     onExpand={() => setShowAllDevices(true)}
                     showExpandButton={true}
                     showGradient={true}
-                    className="px-56 pt-40"
+                    className="px-56 pt-40 pb-158"
                   />
 
                   {/* 담기 버튼 - 하단 고정 */}
-                  <div className="mt-auto pt-30 px-56 pb-56 flex justify-end flex-shrink-0">
+                  <div className="absolute bottom-56 right-56">
                     <PrimaryButton
                       text={isAlreadyInSelectedCombination ? '이미 담은 상품입니다.' : `${selectedCombination.label} 에 담기`}
                       onClick={handleAddDeviceToCombination}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -340,7 +340,7 @@ const DeviceSearchPage = () => {
                       <div className="flex flex-col gap-8">
                         <div className="w-full h-360 bg-gray-200 relative">
                           {/* Color Chip Dropdown */}
-                          <div className="absolute left-20 top-20 bg-white rounded-button shadow-[0_0_4px_rgba(0,0,0,0.25)] p-2 flex items-center">
+                          {/* <div className="absolute left-20 top-20 bg-white rounded-button shadow-[0_0_4px_rgba(0,0,0,0.25)] p-2 flex items-center">
                             <div className="w-40 h-40 flex items-center justify-center">
                               <div
                                 className="w-32 h-32 rounded-full"
@@ -349,15 +349,16 @@ const DeviceSearchPage = () => {
                             </div>
                             <DropdownIcon className="w-28 h-14 text-gray-400" />
                           </div>
-                        </div>
+                        </div> */}
 
                         {/* Page Control (dots) */}
-                        <div className="flex items-center justify-center gap-24 py-8">
+                        {/* <div className="flex items-center justify-center gap-24 py-8">
                           <div className="w-12 h-12 rounded-full bg-black" />
                           <div className="w-12 h-12 rounded-full bg-gray-300" />
                           <div className="w-12 h-12 rounded-full bg-gray-300" />
+                          */}
                         </div>
-                      </div>
+                      </div> 
 
                       {/* Button */}
                       <PrimaryButton

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -9,7 +9,6 @@ import ProductLife from '@/components/ProductCard/ProductLife';
 import FilterDropdown from '@/components/Filter/FilterDropdown';
 import SortDropdown from '@/components/Filter/SortDropdown';
 import SearchIcon from '@/assets/icons/search.svg?react';
-import DropdownIcon from '@/assets/icons/dropdown.svg?react';
 import FilterIcon from '@/assets/icons/filter.svg?react';
 import TopIcon from '@/assets/icons/top.svg?react';
 import XIcon from '@/assets/icons/X.svg?react';

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -25,7 +25,7 @@ const MyPage = () => {
     <div className="min-h-screen bg-white">
       <GNB />
 
-      <div className="flex pt-108">
+      <div className="flex pt-52">
         {/* 좌측 사이드바 */}
         <aside className="flex-shrink-0 ml-160 pt-64 w-280">
           {/* MY Page 헤더 */}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import GNB from '@/components/Home/GNB';
 import PrimaryButton from '@/components/Button/PrimaryButton';
+import SecondaryButton from '@/components/Button/SecondaryButton';
 import SortDropdown from '@/components/Filter/SortDropdown';
 import CombinationDeviceCard from '@/components/Combination/CombinationDeviceCard';
 import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
@@ -67,9 +68,7 @@ const MyPage = () => {
           </div>
 
           {/* 휴지통 버튼 */}
-          <button className="mt-76 w-full h-72 rounded-button bg-blue-100 border border-blue-600 flex items-center justify-center cursor-pointer hover:bg-blue-50 transition-colors">
-            <p className="font-body-2-sm text-blue-600">휴지통</p>
-          </button>
+          <SecondaryButton text="휴지통" className="mt-76 w-full hover:!bg-blue-50 transition-colors" />
         </aside>
 
         {/* 우측 메인 콘텐츠 */}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import GNB from '@/components/Home/GNB';
 import PrimaryButton from '@/components/Button/PrimaryButton';
 import SecondaryButton from '@/components/Button/SecondaryButton';
@@ -20,14 +20,43 @@ const MYPAGE_SORT_OPTIONS = [
 
 const MyPage = () => {
   const [sortOption, setSortOption] = useState('latest');
+  const [isAtBottom, setIsAtBottom] = useState(false);
+  const [columns, setColumns] = useState<3 | 4>(4);
+
+  // 스크롤 감지 (하단 그라데이션용)
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight;
+      setIsAtBottom(scrollTop + windowHeight >= documentHeight - 50);
+    };
+    window.addEventListener('scroll', handleScroll);
+    handleScroll();
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // 브레이크포인트 감지 (칼럼 수 반응형)
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 1536px)');
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setColumns(e.matches ? 4 : 3);
+    };
+    handleChange(mediaQuery);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className={`min-h-screen bg-white relative ${isAtBottom ? 'bg-effect-fade-bottom' : ''}`}>
       <GNB />
 
       <div className="flex pt-52">
         {/* 좌측 사이드바 */}
-        <aside className="flex-shrink-0 ml-160 pt-64 w-280">
+        <aside
+          className="flex-shrink-0 pt-64 w-280"
+          style={{ marginLeft: 'clamp(80px, calc(80px + (100vw - 1440px) * 0.166667), 160px)' }}
+        >
           {/* MY Page 헤더 */}
           <div className="flex items-center justify-between h-72">
             <h1 className="font-heading-2 text-black">MY Page</h1>
@@ -72,7 +101,13 @@ const MyPage = () => {
         </aside>
 
         {/* 우측 메인 콘텐츠 */}
-        <main className="flex-1 pl-159 pr-160 pt-64">
+        <main
+          className="flex-1 pt-64"
+          style={{
+            paddingLeft: 'clamp(80px, calc(80px + (100vw - 1440px) * 0.166667), 160px)',
+            paddingRight: 'clamp(80px, calc(80px + (100vw - 1440px) * 0.166667), 160px)',
+          }}
+        >
           {/* 헤더: 내 조합 + 새 조합 추가하기 */}
           <div className="flex items-center justify-between h-72">
             <h2 className="font-heading-2 text-black">내 조합</h2>
@@ -108,14 +143,14 @@ const MyPage = () => {
                   {/* 조합 카드 */}
                   <div className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.1)] relative">
                     {/* Setting More 버튼 */}
-                    <button className="absolute right-36 top-36 cursor-pointer hover:opacity-80">
+                    <button className="absolute right-56 top-36 cursor-pointer hover:opacity-80">
                       <SettingMoreIcon className="w-36 h-36 text-gray-400" />
                     </button>
 
                     <CombinationDeviceCard
                       combination={combination}
                       devices={devices}
-                      columns={4}
+                      columns={columns}
                       defaultRows={2}
                       showExpandButton={false}
                       showGradient={false}
@@ -128,7 +163,7 @@ const MyPage = () => {
           </div>
 
           {/* 하단 여백 */}
-          <div className="h-100" />
+          <div className="h-268" />
         </main>
       </div>
     </div>


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #60 

## 🔍 구현한 내용

- 기기 전체보기 1440 사이즈 수정하였습니다.
- 기기 전체보기 담기 버튼을 수정하였습니다.
- mypage 휴지통 컴포넌트화 하였습니다. (secondary)
- mypage 1920 상단 마진 조정하여 렌더링 시 휴지통 보이도록 하였습니다.
- mypage 조합카드의 tag 마진 수정하였습니다.
- mypage 1920 Card 내 제품사진 사이즈 수정하였습니다.
- mapage 1440 수정하였습니다.
- 회의 삭제 내용 반영하여, 컬러칩, indicator 삭제하였습니다.

## 📸 스크린샷 or 실행 영상


https://github.com/user-attachments/assets/f35fb734-2122-411d-8d2b-c442039953e3



## 📢 리뷰어에게

(이후 과정)

1. 액세서리 제거 후, 마진 수정
2. 마이페이지 > 자세히 보기
3. 마이페이지 -> 더보기 삭제하기
4. 마이페이지 -> 새 조합 추가된 상태
5. 마이페이지 -> Card ... 누르면 나오는 화면
6. 조합 리스트 개수에 따른 UI, 로직 (검색화면 flow)

휴지통 keep