### PR TITLE
feat: 조합 상세평가 태그 컴포넌트 구현 및 공통 상수/메타 정보 정리

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,22 +5,22 @@
     <link rel="icon" type="image/svg+xml" href="/devicelife.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Device Life</title>
-    <meta name="description" content="최적의 기기 조합 웹 서비스" />
+    <meta name="description" content="나에게 딱 맞는 최적의 기기 조합을 찾아보세요" />
     
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Device Life" />
     <meta property="og:title" content="Device Life" />
-    <meta property="og:description" content="최적의 기기 조합 웹 서비스" />
+    <meta property="og:description" content="나에게 딱 맞는 최적의 기기 조합을 찾아보세요" />
     <meta property="og:url" content="https://devicelife.site" />
     <meta property="og:image" content="https://devicelife.site/og-thumbnail.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Device Life" />
-    <meta name="twitter:description" content="최적의 기기 조합 웹 서비스" />
+    <meta name="twitter:description" content="나에게 딱 맞는 최적의 기기 조합을 찾아보세요" />
     <meta name="twitter:image" content="https://devicelife.site/og-thumbnail.png" />
 
     <meta property="kakao:title" content="Device Life" />
-    <meta property="kakao:description" content="최적의 기기 조합 웹 서비스" />
+    <meta property="kakao:description" content="나에게 딱 맞는 최적의 기기 조합을 찾아보세요" />
     <meta property="kakao:image" content="https://devicelife.site/og-thumbnail.png" />
   </head>
   <body>

--- a/src/components/Combination/CombinationDetailTag.tsx
+++ b/src/components/Combination/CombinationDetailTag.tsx
@@ -1,0 +1,30 @@
+import { COMBINATION_NAME_STYLE_MAP, type CombinationName } from '@/constants/combination';
+
+type CombinationDetailTagProps = {
+  name: CombinationName;
+  info: string;
+  className?: string;
+};
+
+const CombinationDetailTag = ({ name, info, className = '' }: CombinationDetailTagProps) => {
+  const infoText = name === '라이프스타일' ? `#${info}` : info;
+  return (
+    <div
+      className={`
+        inline-flex
+        px-12 py-8
+        justify-center items-center
+        gap-8
+        rounded-tag
+        font-body-2-r
+        cursor-default
+        ${COMBINATION_NAME_STYLE_MAP[name]}
+        ${className}
+      `}
+    >
+      <span>{infoText}</span>
+    </div>
+  );
+};
+
+export default CombinationDetailTag;

--- a/src/components/Combination/CombinationTag.tsx
+++ b/src/components/Combination/CombinationTag.tsx
@@ -1,22 +1,14 @@
-import { type CombinationName, type CombinationStatus } from '@/constants/combination';
+import {
+  COMBINATION_NAME_STYLE_MAP,
+  COMBINATION_STATUS_STYLE_MAP,
+  type CombinationName,
+  type CombinationStatus,
+} from '@/constants/combination';
 
 type CombinationTagProps = {
   name: CombinationName;
   status: CombinationStatus;
   className?: string;
-};
-
-const NAME_STYLE_MAP: Record<CombinationName, string> = {
-  연동성: 'bg-blue-200 text-blue-700',
-  편의성: 'bg-light-green text-dark-green',
-  라이프스타일: 'bg-light-yellow text-dark-yellow',
-};
-
-const STATUS_STYLE_MAP: Record<CombinationStatus, string> = {
-  최적: 'font-caption-sm text-optimal',
-  보통: 'font-caption-sm text-normal',
-  미흡: 'font-caption-sm text-poor',
-  '-': 'font-caption-sm text-optimal',
 };
 
 const CombinationTag = ({ name, status, className = '' }: CombinationTagProps) => {
@@ -27,12 +19,12 @@ const CombinationTag = ({ name, status, className = '' }: CombinationTagProps) =
         px-12 py-8 h-30
         rounded-tag
         font-caption-r
-        ${NAME_STYLE_MAP[name]}
+        ${COMBINATION_NAME_STYLE_MAP[name]}
         ${className}
       `}
     >
       <span>{name}:</span>
-      <span className={STATUS_STYLE_MAP[status]}>{status}</span>
+      <span className={COMBINATION_STATUS_STYLE_MAP[status]}>{status}</span>
     </span>
   );
 };

--- a/src/constants/combination.ts
+++ b/src/constants/combination.ts
@@ -4,6 +4,19 @@ export const COMBINATION_STATUSES = ['최적', '보통', '미흡', '-'] as const
 export type CombinationName = (typeof COMBINATION_NAMES)[number];
 export type CombinationStatus = (typeof COMBINATION_STATUSES)[number];
 
+export const COMBINATION_NAME_STYLE_MAP: Record<CombinationName, string> = {
+  연동성: 'bg-blue-200 text-blue-700',
+  편의성: 'bg-light-green text-dark-green',
+  라이프스타일: 'bg-light-yellow text-dark-yellow',
+};
+
+export const COMBINATION_STATUS_STYLE_MAP: Record<CombinationStatus, string> = {
+  최적: 'font-caption-sm text-optimal',
+  보통: 'font-caption-sm text-normal',
+  미흡: 'font-caption-sm text-poor',
+  '-': 'font-caption-sm text-optimal',
+};
+
 export const COMBO_MOTION = {
   HEADER_H: 80,
 


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #71 

## 🔍 구현한 내용
- 조합 상세평가 태그 컴포넌트를 구현했습니다.
  - `name`과 `info`만 전달하면 폰트 및 색상이 자동으로 매핑되도록 구성했습니다.
  - 라이프스타일의 경우, `info` 앞에 `#`를 직접 붙이지 않아도 자동으로 처리됩니다.
  - 사용 예시는 아래와 같습니다.
    ```tsx
    <CombinationDetailTag name="연동성" info="iCloud 동기화" />
    <CombinationDetailTag name="편의성" info="N개 기기 해당" />
    <CombinationDetailTag name="라이프스타일" info="Game" />
     ```
- CombinationTag, CombinationDetailTag에서 공통으로 사용되는 스타일 매핑 정보를 상수로 분리했습니다. 
- `index.html`의 description 메타 태그 문구를 서비스 내용에 맞게 수정했습니다.

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/022783f6-0067-475f-8cc2-3c6ed65fdfb3


## 📢 리뷰어에게
