### PR TITLE
feature: 기기 상세보기 모달  flow 로직 구현, css 수정

### DIFF
--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -56,7 +56,7 @@ const CombinationDeviceCard = ({
           <p className="font-body-3-r text-gray-400">{combination.label}</p>
           <div className="flex items-center gap-8">
             <p className="font-body-1-sm text-black">{combination.name}</p>
-            {combination.isMain && <StarIcon className="w-27 h-27" />}
+            {combination.isMain && <StarIcon className="w-22 h-22" />}
           </div>
         </div>
         {/* Tags */}

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -43,6 +43,13 @@ const CombinationDeviceCard = ({
     onExpand?.(true);
   };
 
+  const handleCollapse = () => {
+    if (!isControlled) {
+      setInternalExpanded(false);
+    }
+    onExpand?.(false);
+  };
+
   const gridColsClass = columns === 4 ? 'grid-cols-4' : 'grid-cols-3';
   const deviceCardWidth = columns === 4 ? 'w-244' : 'w-244';
   const deviceImageSize = columns === 4 ? 'w-64 h-64' : 'w-64 h-64';
@@ -96,13 +103,21 @@ const CombinationDeviceCard = ({
         )}
       </div>
 
-      {/* 기기 전체보기 버튼 */}
+      {/* 기기 전체보기 / 간략히 보기 버튼 */}
       {showExpandButton && hasMoreDevices && !showAllDevices && (
         <button
           onClick={handleExpand}
           className="mt-16 pl-12 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80"
         >
           기기 전체보기
+        </button>
+      )}
+      {showExpandButton && hasMoreDevices && showAllDevices && (
+        <button
+          onClick={handleCollapse}
+          className="mt-16 pl-12 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80"
+        >
+          간략히 보기
         </button>
       )}
     </div>

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -95,9 +95,9 @@ export const MOCK_COMBINATIONS: UserCombination[] = [
     isMain: false,
     createdAt: '2026.01.10',
     tags: [
-      { name: '연동성', status: '양호' },
+      { name: '연동성', status: '보통' },
       { name: '편의성', status: '최적' },
-      { name: '라이프스타일', status: '양호' },
+      { name: '라이프스타일', status: '보통' },
     ],
   },
   {
@@ -108,7 +108,7 @@ export const MOCK_COMBINATIONS: UserCombination[] = [
     createdAt: '2026.01.15',
     tags: [
       { name: '연동성', status: '최적' },
-      { name: '편의성', status: '양호' },
+      { name: '편의성', status: '보통' },
       { name: '라이프스타일', status: '최적' },
     ],
   },

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -88,6 +88,30 @@ export const MOCK_COMBINATIONS: UserCombination[] = [
       { name: '라이프스타일', status: '-' },
     ],
   },
+  {
+    id: 5,
+    label: '조합 5',
+    name: '게이밍 셋업',
+    isMain: false,
+    createdAt: '2026.01.10',
+    tags: [
+      { name: '연동성', status: '양호' },
+      { name: '편의성', status: '최적' },
+      { name: '라이프스타일', status: '양호' },
+    ],
+  },
+  {
+    id: 6,
+    label: '조합 6',
+    name: '출퇴근용 조합',
+    isMain: false,
+    createdAt: '2026.01.15',
+    tags: [
+      { name: '연동성', status: '최적' },
+      { name: '편의성', status: '양호' },
+      { name: '라이프스타일', status: '최적' },
+    ],
+  },
 ];
 
 // 조합별 기기 목록 (추후 API 연동)
@@ -128,4 +152,15 @@ export const MOCK_COMBINATION_DEVICES: Record<number, DeviceSummary[]> = {
   ],
   // 조합4: 새로 생성한 조합 (기기 없음)
   4: [],
+  // 조합5: 게이밍 셋업
+  5: [
+    { id: 301, name: 'ROG Ally', chargingType: 'USB-C', color: '화이트', image: null },
+    { id: 302, name: 'ROG 게이밍 모니터', chargingType: 'USB-C', color: '블랙', image: null },
+    { id: 303, name: '로지텍 G Pro 마우스', chargingType: 'USB-C', color: '블랙', image: null },
+  ],
+  // 조합6: 출퇴근용 조합
+  6: [
+    { id: 401, name: 'AirPods Pro 2세대', chargingType: 'USB-C', color: '화이트', image: null },
+    { id: 402, name: 'Apple Watch Series 9', chargingType: 'MagSafe', color: '미드나이트', image: null },
+  ],
 };

--- a/src/index.css
+++ b/src/index.css
@@ -366,3 +366,36 @@ body {
 .animate-lines-appear {
   animation: linesAppear 2s ease-out forwards;
 }
+
+/* 미니멀 스크롤바 */
+.scrollbar-minimal {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.scrollbar-minimal:hover {
+  scrollbar-color: var(--color-gray-200) transparent;
+}
+
+/* Webkit (Chrome, Safari, Edge) */
+.scrollbar-minimal::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollbar-minimal::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-minimal::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 1000px;
+  transition: background-color 0.2s ease;
+}
+
+.scrollbar-minimal:hover::-webkit-scrollbar-thumb {
+  background-color: var(--color-gray-200);
+}
+
+.scrollbar-minimal::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-gray-300);
+}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -45,6 +45,7 @@ const DeviceSearchPage = () => {
   const [selectedCombinationId, setSelectedCombinationId] = useState<number | null>(null);
   const [showAllDevices, setShowAllDevices] = useState(false);
   const [showSaveCompleteModal, setShowSaveCompleteModal] = useState(false);
+  const [isFadingOut, setIsFadingOut] = useState(false);
 
   const productGridRef = useRef<HTMLDivElement>(null);
 
@@ -106,11 +107,21 @@ const DeviceSearchPage = () => {
   /* 저장 완료 모달 자동 닫기 */
   useEffect(() => {
     if (showSaveCompleteModal) {
-      const timer = setTimeout(() => {
-        setShowSaveCompleteModal(false);
-        handleCloseModal();
+      // 1. 0.8초 유지
+      const holdTimer = setTimeout(() => {
+        setIsFadingOut(true);
+
+        // 2. 0.2초 동안 dissolve (fade-out) 후 종료
+        const closeTimer = setTimeout(() => {
+          setShowSaveCompleteModal(false);
+          setIsFadingOut(false);
+          handleCloseModal();
+        }, 200); // 0.2초
+
+        return () => clearTimeout(closeTimer);
       }, 800); // 0.8초
-      return () => clearTimeout(timer);
+
+      return () => clearTimeout(holdTimer);
     }
   }, [showSaveCompleteModal]);
 
@@ -542,8 +553,8 @@ const DeviceSearchPage = () => {
       {/* 저장 완료 모달 - 독립적으로 표시 */}
       {showSaveCompleteModal && (
         <>
-          <div className="fixed inset-0 bg-black/50 z-60" />
-          <div className="fixed inset-0 flex items-center justify-center z-80">
+          <div className={`fixed inset-0 bg-black/50 z-60 transition-opacity duration-200 ${isFadingOut ? 'opacity-0' : 'opacity-100'}`} />
+          <div className={`fixed inset-0 flex items-center justify-center z-80 transition-opacity duration-200 ${isFadingOut ? 'opacity-0' : 'opacity-100'}`}>
             <div className="w-300 h-300 bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] relative animate-fade-in">
               <SaveIcon className="w-100 h-100 text-blue-600 absolute left-1/2 -translate-x-1/2 top-64" />
               <p className="font-heading-3 text-blue-600 absolute left-1/2 -translate-x-1/2 top-206">저장 완료!</p>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -338,7 +338,7 @@ const DeviceSearchPage = () => {
                 <div
                   className="bg-white rounded-card px-56 py-40"
                   style={{
-                    width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)',
+                    width: '907px',
                     height: '697px',
                   }}
                   onClick={(e) => e.stopPropagation()}
@@ -351,15 +351,15 @@ const DeviceSearchPage = () => {
                       <div className="flex flex-col gap-20">
                         {/* Name & Price */}
                         <div className="flex flex-col gap-12">
-                          <p className="font-heading-1 text-black">{selectedProduct.name}</p>
-                          <div className="flex items-center gap-8 font-heading-2 text-blue-600">
+                          <p className="font-heading-1 text-blue-600">{selectedProduct.name}</p>
+                          <div className="flex items-center gap-8 font-heading-2 text-gray-500">
                             <p>₩</p>
                             <p>{selectedProduct.price.toLocaleString()}</p>
                           </div>
                         </div>
 
                         {/* Image */}
-                        <div className="w-full h-360 bg-gray-200 relative">
+                        <div className="w-400 h-400 bg-gray-200 relative">
                         </div>
                       </div>
 
@@ -372,39 +372,39 @@ const DeviceSearchPage = () => {
                     </div>
 
                     {/* Right Section */}
-                    <div className="w-302 flex flex-col gap-56 pt-126">
+                    <div className="w-302 flex flex-col gap-40 pt-126">
                       {/* Product Info Table */}
-                      <div className="flex flex-col justify-between h-360 pl-16">
-                        <div className="flex items-center gap-80">
-                          <p className="font-body-1-r text-gray-400">모델명</p>
-                          <p className="font-body-1-r text-black">{selectedProduct.name}</p>
+                      <div className="flex flex-col justify-between h-400 pl-16">
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">모델명</p>
+                          <p className="font-body-2-r text-black">{selectedProduct.name}</p>
                         </div>
-                        <div className="flex items-center gap-58">
-                          <p className="font-body-1-r text-gray-400">카테고리</p>
-                          <p className="font-body-1-r text-black">{selectedProduct.category}</p>
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">카테고리</p>
+                          <p className="font-body-2-r text-black">{selectedProduct.category}</p>
                         </div>
-                        <div className="flex items-center gap-78">
-                          <p className="font-body-1-r text-gray-400">브랜드</p>
-                          <p className="font-body-1-r text-black">Apple</p>
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">브랜드</p>
+                          <p className="font-body-2-r text-black">Apple</p>
                         </div>
-                        <div className="flex items-center gap-100">
-                          <p className="font-body-1-r text-gray-400">색상</p>
-                          <p className="font-body-1-r text-black">내추럴 티타늄</p>
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">색상</p>
+                          <p className="font-body-2-r text-black">내추럴 티타늄</p>
                         </div>
-                        <div className="flex items-center gap-100">
-                          <p className="font-body-1-r text-gray-400">가격</p>
-                          <div className="flex items-center gap-4 font-body-1-r text-black">
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">가격</p>
+                          <div className="flex items-center gap-4 font-body-2-r text-black">
                             <p>{selectedProduct.price.toLocaleString()}</p>
                             <p>원</p>
                           </div>
                         </div>
-                        <div className="flex items-center gap-56">
-                          <p className="font-body-1-r text-gray-400">충전방식</p>
-                          <p className="font-body-1-r text-black">USB-C</p>
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">충전방식</p>
+                          <p className="font-body-2-r text-black">USB-C</p>
                         </div>
-                        <div className="flex items-center gap-80">
-                          <p className="font-body-1-r text-gray-400">출시일</p>
-                          <p className="font-body-1-r text-black">2023년 9월</p>
+                        <div className="flex items-center gap-24">
+                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">출시일</p>
+                          <p className="font-body-2-r text-black">2023년 9월</p>
                         </div>
                       </div>
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -443,13 +443,13 @@ const DeviceSearchPage = () => {
                 <div
                   className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)]"
                   style={{
-                    width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)',
-                    height: '697px',
+                    width: '907px',
+                    height: '670px',
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {/* Combination List */}
-                  <div className="flex flex-col mx-20 overflow-y-auto max-h-[657px] scrollbar-minimal">
+                  <div className="flex flex-col mx-20 overflow-y-auto max-h-[630px] scrollbar-minimal">
                     {MOCK_COMBINATIONS.map((combo) => (
                       <button
                         key={combo.id}
@@ -488,7 +488,7 @@ const DeviceSearchPage = () => {
             {modalView === 'combinationDetail' && selectedCombination && (
               <div
                 className="flex flex-col items-start gap-20 pointer-events-auto self-start"
-                style={{ marginTop: 'calc((100vh - 765px) / 2)' }}
+                style={{ marginTop: 'calc((100vh - 738px) / 2)' }}
               >
                 {/* Header: Back + X 버튼 */}
                 <div className="flex items-center justify-between w-full">
@@ -512,10 +512,8 @@ const DeviceSearchPage = () => {
                 <div
                   className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] relative"
                   style={{
-                    width: 'clamp(903px, calc(903px + (100vw - 1440px) * 0.245833), 1021px)',
-                    height: showAllDevices
-                      ? 'clamp(700px, calc(700px + (100vw - 1440px) * 0.0625), 730px)'
-                      : '697px',
+                    width: '907px',
+                    height: showAllDevices ? '700px' : '670px',
                     transition: 'height 0.3s ease',
                   }}
                   onClick={(e) => e.stopPropagation()}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -339,7 +339,7 @@ const DeviceSearchPage = () => {
                   className="bg-white rounded-card px-56 py-40"
                   style={{
                     width: '907px',
-                    height: '697px',
+                    height: '670px',
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -525,7 +525,7 @@ const DeviceSearchPage = () => {
                     columns={3}
                     defaultRows={3}
                     expanded={showAllDevices}
-                    onExpand={() => setShowAllDevices(true)}
+                    onExpand={(value) => setShowAllDevices(value)}
                     showExpandButton={true}
                     showGradient={true}
                     className="px-56 pt-40 pb-158"

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -376,34 +376,34 @@ const DeviceSearchPage = () => {
                       {/* Product Info Table */}
                       <div className="flex flex-col justify-between h-400 pl-16">
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">모델명</p>
+                          <p className="font-body-2-r text-gray-400 w-80">모델명</p>
                           <p className="font-body-2-r text-black">{selectedProduct.name}</p>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">카테고리</p>
+                          <p className="font-body-2-r text-gray-400 w-80">카테고리</p>
                           <p className="font-body-2-r text-black">{selectedProduct.category}</p>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">브랜드</p>
+                          <p className="font-body-2-r text-gray-400 w-80">브랜드</p>
                           <p className="font-body-2-r text-black">Apple</p>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">색상</p>
+                          <p className="font-body-2-r text-gray-400 w-80">색상</p>
                           <p className="font-body-2-r text-black">내추럴 티타늄</p>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">가격</p>
+                          <p className="font-body-2-r text-gray-400 w-80">가격</p>
                           <div className="flex items-center gap-4 font-body-2-r text-black">
                             <p>{selectedProduct.price.toLocaleString()}</p>
                             <p>원</p>
                           </div>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">충전방식</p>
+                          <p className="font-body-2-r text-gray-400 w-80">충전방식</p>
                           <p className="font-body-2-r text-black">USB-C</p>
                         </div>
                         <div className="flex items-center gap-24">
-                          <p className="font-body-2-r text-gray-400 whitespace-nowrap">출시일</p>
+                          <p className="font-body-2-r text-gray-400 w-80">출시일</p>
                           <p className="font-body-2-r text-black">2023년 9월</p>
                         </div>
                       </div>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -346,7 +346,7 @@ const DeviceSearchPage = () => {
                   {/* Content */}
                   <div className="flex items-start justify-between gap-56">
                     {/* Left Section */}
-                    <div className="w-400 flex flex-col gap-32">
+                    <div className="w-400 flex flex-col gap-20">
                       {/* Name & Price + Image */}
                       <div className="flex flex-col gap-20">
                         {/* Name & Price */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -464,7 +464,7 @@ const DeviceSearchPage = () => {
                             {/* 조합명 + 대표조합 star */}
                             <div className="flex items-center gap-8">
                               <p className="font-body-1-sm text-black">{combo.name}</p>
-                              {combo.isMain && <StarIcon className="w-27 h-27" />}
+                              {combo.isMain && <StarIcon className="w-22 h-22" />}
                             </div>
                           </div>
                           {/* Tags */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -449,7 +449,7 @@ const DeviceSearchPage = () => {
                   onClick={(e) => e.stopPropagation()}
                 >
                   {/* Combination List */}
-                  <div className="flex flex-col mx-20">
+                  <div className="flex flex-col mx-20 overflow-y-auto max-h-[657px] scrollbar-minimal">
                     {MOCK_COMBINATIONS.map((combo) => (
                       <button
                         key={combo.id}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -534,7 +534,7 @@ const DeviceSearchPage = () => {
                   />
 
                   {/* 담기 버튼 - 하단 고정 */}
-                  <div className="absolute bottom-56 right-56">
+                  <div className="absolute bottom-40 right-40">
                     <PrimaryButton
                       text={isAlreadyInSelectedCombination ? '이미 담은 상품입니다.' : `${selectedCombination.label} 에 담기`}
                       onClick={handleAddDeviceToCombination}


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #79 

## 🔍 구현한 내용

- 기기 리스트가 5개 이상일 경우 스크롤 구현하였습니다.

디자이너님 의견 반영하여, 스크롤 구현하면서 같은 모달 flow라서 css 수정하였습니다.

- 기기 조합 저장 팝업이 꺼질 때 css 수정하였습니다.
- <조합1에 담기> 버튼 하단과 우측 마진 조정하였습니다.
- starIcon 크기 수정하였습니다.
- 기기 상세정보 모달, 마진 글꼴 수정하였습니다.
- 기기 상세정보 height 수정하였습니다.
- 이후 flow width, height 동일 수정하였습니다.
- 기기 자세히 보기를 누르면, 간략히 보기도 뜨도록 구현하였습니다.
- 기기상세보기 스펙 글꼴 마진 조절하였습니다.

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
