### PR TITLE
feat: 마이페이지 flow 추가 구현하였습니다.

### DIFF
--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -36,6 +36,9 @@ const CombinationDeviceCard = ({
   const hasMoreDevices = devices.length > defaultDeviceCount;
   const displayedDevices = showAllDevices ? devices : devices.slice(0, defaultDeviceCount);
 
+  const gradientThreshold = columns === 4 ? 9 : 7;
+  const shouldShowGradient = devices.length >= gradientThreshold;
+
   const handleExpand = () => {
     if (!isControlled) {
       setInternalExpanded(true);
@@ -67,7 +70,7 @@ const CombinationDeviceCard = ({
           </div>
         </div>
         {/* Tags */}
-        <div className="flex gap-12">
+        <div className="flex gap-12 -ml-4">
           {combination.tags.map((tag) => (
             <CombinationTag key={tag.name} name={tag.name} status={tag.status} />
           ))}
@@ -93,7 +96,7 @@ const CombinationDeviceCard = ({
         </div>
 
         {/* 그라데이션 */}
-        {showGradient && hasMoreDevices && !showAllDevices && (
+        {showGradient && shouldShowGradient && !showAllDevices && (
           <div
             className={`absolute right-0 bottom-0 ${deviceCardWidth} h-80 rounded-card pointer-events-none`}
             style={{

--- a/src/components/RecentlyViewed/RecentlyViewedCard.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedCard.tsx
@@ -1,0 +1,42 @@
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+
+interface RecentlyViewedCardProps {
+  device: RecentlyViewedDevice;
+  onClick?: () => void;
+}
+
+const RecentlyViewedCard = ({ device, onClick }: RecentlyViewedCardProps) => {
+  return (
+    <div
+      onClick={onClick}
+      className="w-[189px] px-20 py-16 rounded-[6px] cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow"
+    >
+      {/* 이미지 - 149x149 */}
+      <div className="w-[149px] h-[149px] bg-gray-200 rounded-[6px] overflow-hidden">
+        {device.image && (
+          <img
+            src={device.image}
+            alt={device.name}
+            className="w-full h-full object-cover"
+          />
+        )}
+      </div>
+
+      {/* 콘텐츠 */}
+      <div className="flex flex-col gap-2 mt-12">
+        {/* 제품명 - 16px, Regular, line-height 22px */}
+        <p className="font-body-2-r text-black leading-[22px] truncate">{device.name}</p>
+
+        {/* 카테고리 - 12px, SemiBold, Gray300 */}
+        <p className="font-caption-sm text-gray-300">{device.category}</p>
+
+        {/* 가격 - 16px, SemiBold */}
+        <p className="font-body-2-sm text-black mt-8">
+          {device.price.toLocaleString()}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RecentlyViewedCard;

--- a/src/components/RecentlyViewed/RecentlyViewedCard.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedCard.tsx
@@ -9,10 +9,10 @@ const RecentlyViewedCard = ({ device, onClick }: RecentlyViewedCardProps) => {
   return (
     <div
       onClick={onClick}
-      className="w-[189px] px-20 py-16 rounded-[6px] cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow"
+      className="w-189 px-20 py-16 cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow"
     >
       {/* 이미지 - 149x149 */}
-      <div className="w-[149px] h-[149px] bg-gray-200 rounded-[6px] overflow-hidden">
+      <div className="w-149 h-149 bg-gray-200 overflow-hidden">
         {device.image && (
           <img
             src={device.image}
@@ -25,7 +25,7 @@ const RecentlyViewedCard = ({ device, onClick }: RecentlyViewedCardProps) => {
       {/* 콘텐츠 */}
       <div className="flex flex-col gap-2 mt-12">
         {/* 제품명 - 16px, Regular, line-height 22px */}
-        <p className="font-body-2-r text-black leading-[22px] truncate">{device.name}</p>
+        <p className="font-body-2-r text-black leading-22 truncate">{device.name}</p>
 
         {/* 카테고리 - 12px, SemiBold, Gray300 */}
         <p className="font-caption-sm text-gray-300">{device.category}</p>

--- a/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
@@ -1,0 +1,103 @@
+import { useRef, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+import RecentlyViewedCard from './RecentlyViewedCard';
+
+interface RecentlyViewedFloatingProps {
+  userName: string;
+  sidebarContentRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const RecentlyViewedFloating = ({
+  userName,
+  sidebarContentRef,
+}: RecentlyViewedFloatingProps) => {
+  const navigate = useNavigate();
+  const { devices } = useRecentlyViewed();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isFloating, setIsFloating] = useState(false);
+  const [leftPosition, setLeftPosition] = useState(0);
+
+  // 표시할 기기 (최대 2개)
+  const displayDevices = devices.slice(0, 2);
+
+  useEffect(() => {
+    const updatePosition = () => {
+      if (!sidebarContentRef.current) return;
+
+      const sidebarRect = sidebarContentRef.current.getBoundingClientRect();
+      const GNB_HEIGHT = 80;
+      const MARGIN_TOP = 60;
+
+      // 사이드바 콘텐츠의 하단이 GNB + 마진 위로 올라갔을 때 플로팅 시작
+      const threshold = GNB_HEIGHT + MARGIN_TOP + 60;
+
+      if (sidebarRect.bottom < threshold) {
+        setIsFloating(true);
+        setLeftPosition(sidebarRect.left);
+      } else {
+        setIsFloating(false);
+      }
+    };
+
+    const handleScroll = () => {
+      requestAnimationFrame(updatePosition);
+    };
+
+    const handleResize = () => {
+      updatePosition();
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('resize', handleResize);
+    updatePosition();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [sidebarContentRef]);
+
+  // 기기가 없으면 렌더링하지 않음
+  if (displayDevices.length === 0) return null;
+
+  const handleCardClick = (deviceId: number) => {
+    navigate(`/devices?productId=${deviceId}`);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={`w-280 mt-60 transition-all duration-300 ${
+        isFloating ? 'fixed z-40' : 'relative'
+      }`}
+      style={
+        isFloating
+          ? {
+              top: 140,
+              left: leftPosition,
+            }
+          : undefined
+      }
+    >
+      {/* 헤더 */}
+      <div className="pl-20 mb-28">
+        <span className="font-heading-3 text-black">{userName}</span>
+        <span className="font-heading-4 text-black"> 님이 최근에 본</span>
+      </div>
+
+      {/* 카드 목록 - 세로 배치, 최대 2개 */}
+      <div className="flex flex-col gap-28">
+        {displayDevices.map((device) => (
+          <RecentlyViewedCard
+            key={device.id}
+            device={device}
+            onClick={() => handleCardClick(device.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RecentlyViewedFloating;

--- a/src/constants/mockData.ts
+++ b/src/constants/mockData.ts
@@ -164,3 +164,9 @@ export const MOCK_COMBINATION_DEVICES: Record<number, DeviceSummary[]> = {
     { id: 402, name: 'Apple Watch Series 9', chargingType: 'MagSafe', color: '미드나이트', image: null },
   ],
 };
+
+// 최근에 본 기기 Mock 데이터
+export const MOCK_RECENTLY_VIEWED_DEVICES = [
+  { id: 1, name: 'iPhone 15 pro', category: '스마트폰', price: 1550000, image: null, viewedAt: Date.now() },
+  { id: 2, name: 'Galaxy S24', category: '스마트폰', price: 1200000, image: null, viewedAt: Date.now() - 1000 },
+];

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,3 @@
+// localStorage 키 상수
+export const RECENTLY_VIEWED_DEVICES = 'RECENTLY_VIEWED_DEVICES';
+export const RECENTLY_VIEWED_MAX_COUNT = 2;

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,3 +1,3 @@
 // localStorage 키 상수
 export const RECENTLY_VIEWED_DEVICES = 'RECENTLY_VIEWED_DEVICES';
-export const RECENTLY_VIEWED_MAX_COUNT = 2;
+export const RECENTLY_VIEWED_MAX_COUNT = 10;

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+import {
+  getRecentlyViewedDevices,
+  addRecentlyViewedDevice,
+  removeRecentlyViewedDevice,
+} from '@/utils/recentlyViewedStorage';
+
+export const useRecentlyViewed = () => {
+  const [devices, setDevices] = useState<RecentlyViewedDevice[]>([]);
+
+  // 초기 로드
+  useEffect(() => {
+    setDevices(getRecentlyViewedDevices());
+  }, []);
+
+  // 기기 추가
+  const addDevice = useCallback((device: Omit<RecentlyViewedDevice, 'viewedAt'>) => {
+    addRecentlyViewedDevice(device);
+    setDevices(getRecentlyViewedDevices());
+  }, []);
+
+  // 기기 제거
+  const removeDevice = useCallback((deviceId: number) => {
+    removeRecentlyViewedDevice(deviceId);
+    setDevices(getRecentlyViewedDevices());
+  }, []);
+
+  return {
+    devices,
+    addDevice,
+    removeDevice,
+    hasDevices: devices.length > 0,
+  };
+};

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -5,13 +5,19 @@ import {
   addRecentlyViewedDevice,
   removeRecentlyViewedDevice,
 } from '@/utils/recentlyViewedStorage';
+import { MOCK_RECENTLY_VIEWED_DEVICES } from '@/constants/mockData';
 
 export const useRecentlyViewed = () => {
   const [devices, setDevices] = useState<RecentlyViewedDevice[]>([]);
 
-  // 초기 로드
+  // 초기 로드 (localStorage가 비어있으면 mockdata 사용)
   useEffect(() => {
-    setDevices(getRecentlyViewedDevices());
+    const storedDevices = getRecentlyViewedDevices();
+    if (storedDevices.length > 0) {
+      setDevices(storedDevices);
+    } else {
+      setDevices(MOCK_RECENTLY_VIEWED_DEVICES);
+    }
   }, []);
 
   // 기기 추가

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -468,7 +468,7 @@ const DeviceSearchPage = () => {
                             </div>
                           </div>
                           {/* Tags */}
-                          <div className="flex gap-12">
+                          <div className="flex gap-12 -ml-4">
                             {combo.tags.map((tag) => (
                               <CombinationTag key={tag.name} name={tag.name} status={tag.status} />
                             ))}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -449,7 +449,11 @@ const DeviceSearchPage = () => {
                   onClick={(e) => e.stopPropagation()}
                 >
                   {/* Combination List */}
+<<<<<<< HEAD
                   <div className="flex flex-col ml-20 overflow-y-auto h-full scrollbar-minimal">
+=======
+                  <div className="flex flex-col mx-20 overflow-y-auto max-h-630 scrollbar-minimal">
+>>>>>>> 17715f7 (feat: 플로팅메뉴 mock)
                     {MOCK_COMBINATIONS.map((combo) => (
                       <button
                         key={combo.id}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -449,11 +449,7 @@ const DeviceSearchPage = () => {
                   onClick={(e) => e.stopPropagation()}
                 >
                   {/* Combination List */}
-<<<<<<< HEAD
-                  <div className="flex flex-col ml-20 overflow-y-auto h-full scrollbar-minimal">
-=======
                   <div className="flex flex-col mx-20 overflow-y-auto max-h-630 scrollbar-minimal">
->>>>>>> 17715f7 (feat: 플로팅메뉴 mock)
                     {MOCK_COMBINATIONS.map((combo) => (
                       <button
                         key={combo.id}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import GNB from '@/components/Home/GNB';
 import PrimaryButton from '@/components/Button/PrimaryButton';
+import SecondaryButton from '@/components/Button/SecondaryButton';
 import SortDropdown from '@/components/Filter/SortDropdown';
 import CombinationTag from '@/components/Combination/CombinationTag';
 import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
@@ -16,6 +17,7 @@ import CheckboxIcon from '@/assets/icons/checkbox.svg?react';
 import CheckboxOnIcon from '@/assets/icons/checkbox_on.svg?react';
 import TrashIcon from '@/assets/icons/trash.svg?react';
 import RemoveIcon from '@/assets/icons/remove.svg?react';
+import SaveIcon from '@/assets/icons/save.svg?react';
 import Logo from '@/assets/logos/logo.svg?react';
 import { MOCK_COMBINATIONS, MOCK_COMBINATION_DEVICES } from '@/constants/mockData';
 
@@ -57,6 +59,9 @@ const MyPage = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showCombinationDeleteModal, setShowCombinationDeleteModal] = useState(false);
   const [deleteTargetIndex, setDeleteTargetIndex] = useState<number | null>(null);
+  const [editingCombinationIndex, setEditingCombinationIndex] = useState<number | null>(null);
+  const [editingCombinationName, setEditingCombinationName] = useState('');
+  const [showSaveModal, setShowSaveModal] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   // 스크롤 감지 (하단 그라데이션용)
@@ -153,6 +158,14 @@ const MyPage = () => {
       setDetailViewIndex(null);
       setSelectedDevices([]);
     }
+  };
+
+  // 조합명 저장 핸들러
+  const handleSaveCombinationName = () => {
+    // API 연동 시 실제 저장 로직 추가
+    console.log('저장된 조합명:', editingCombinationName);
+    setShowSaveModal(false);
+    setEditingCombinationIndex(null);
   };
 
   return (
@@ -290,7 +303,7 @@ const MyPage = () => {
                         : 'bg-white shadow-[0_0_10px_rgba(0,0,0,0.1)] cursor-pointer hover:bg-gray-50 transition-colors'
                     }`}
                   >
-                    {/* 일반 모드: Setting More 버튼 + 드롭다운 */}
+                    {/* 일반 모드: Setting More 버튼 + 드롭다운 또는 저장하기 버튼 */}
                     {!isDetailView && (
                       <div
                         ref={openMenuIndex === index ? menuRef : null}
@@ -298,7 +311,7 @@ const MyPage = () => {
                       >
                         <button
                           onClick={(e) => {
-                            e.stopPropagation(); // 카드 클릭 이벤트 전파 방지
+                            e.stopPropagation();
                             setOpenMenuIndex(openMenuIndex === index ? null : index);
                           }}
                           className="cursor-pointer hover:opacity-80"
@@ -325,6 +338,24 @@ const MyPage = () => {
                                 <div className="absolute -inset-x-4 inset-y-4 bg-gray-100 rounded-button -z-10" />
                               )}
                               삭제하기
+                            </button>
+
+                            {/* 조합명 수정하기 */}
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setEditingCombinationIndex(index);
+                                setEditingCombinationName(combination.name);
+                                setOpenMenuIndex(null);
+                              }}
+                              onMouseEnter={() => setHoveredMenuItem('rename')}
+                              onMouseLeave={() => setHoveredMenuItem(null)}
+                              className="relative font-body-1-sm text-black text-left py-12 whitespace-nowrap cursor-pointer border-b border-black/50"
+                            >
+                              {hoveredMenuItem === 'rename' && (
+                                <div className="absolute -inset-x-4 inset-y-4 bg-gray-100 rounded-button -z-10" />
+                              )}
+                              조합명 수정하기
                             </button>
 
                             {/* 자세히보기 */}
@@ -411,7 +442,8 @@ const MyPage = () => {
                             {devices.map((device) => (
                               <div
                                 key={device.id}
-                                className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border ${selectedDevices.includes(device.id) ? 'border-blue-600' : 'border-transparent'}`}
+                                onClick={() => window.open(`/devices?productId=${device.id}`, '_blank')}
+                                className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border cursor-pointer hover:shadow-[0_0_8px_rgba(0,0,0,0.15)] transition-shadow ${selectedDevices.includes(device.id) ? 'border-blue-600' : 'border-transparent'}`}
                               >
                                 <div className="w-64 h-64 bg-gray-200 flex-shrink-0" />
                                 <div className="flex flex-col gap-4 flex-1">
@@ -421,7 +453,10 @@ const MyPage = () => {
                                     </p>
                                     {/* 체크박스 - 기기명과 같은 높이 */}
                                     <button
-                                      onClick={() => handleSelectDevice(device.id)}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleSelectDevice(device.id);
+                                      }}
                                       className="cursor-pointer flex-shrink-0"
                                     >
                                       {selectedDevices.includes(device.id) ? (
@@ -438,7 +473,10 @@ const MyPage = () => {
                             ))}
                             {/* 기기 추가 버튼 */}
                             <button
-                              onClick={() => navigate('/devices')}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                navigate('/devices');
+                              }}
                               className="cursor-pointer hover:opacity-80"
                             >
                               <PlusIcon />
@@ -478,7 +516,7 @@ const MyPage = () => {
                               <p className="font-body-3-r text-black leading-28">
                                 {MOCK_EVALUATION.connectivity.description}
                               </p>
-                              <div className="flex gap-8">
+                              <div className="flex gap-8 -ml-4">
                                 {MOCK_EVALUATION.connectivity.tags.map((tag) => (
                                   <span
                                     key={tag}
@@ -501,7 +539,7 @@ const MyPage = () => {
                               <p className="font-body-3-r text-black leading-28">
                                 {MOCK_EVALUATION.convenience.description}
                               </p>
-                              <div className="flex gap-8">
+                              <div className="flex gap-8 -ml-4">
                                 {MOCK_EVALUATION.convenience.tags.map((tag) => (
                                   <span
                                     key={tag}
@@ -524,7 +562,7 @@ const MyPage = () => {
                               <p className="font-body-3-r text-black leading-28">
                                 {MOCK_EVALUATION.lifestyle.description}
                               </p>
-                              <div className="flex gap-8">
+                              <div className="flex gap-8 -ml-4">
                                 {MOCK_EVALUATION.lifestyle.tags.map((tag) => (
                                   <span
                                     key={tag}
@@ -548,9 +586,9 @@ const MyPage = () => {
                               {/* 조합 번호 + 생성일 + 조합명 */}
                               <div className="flex flex-col gap-8">
                                 <div className="flex items-center gap-16">
-                                  <p className="font-body-4-r text-gray-400">{combination.label}</p>
+                                  <p className="font-body-3-r text-gray-400">{combination.label}</p>
                                   {combination.createdAt && (
-                                    <p className="font-body-4-r text-gray-400">
+                                    <p className="font-body-3-r text-gray-400">
                                       생성일: {combination.createdAt}
                                     </p>
                                   )}
@@ -561,7 +599,7 @@ const MyPage = () => {
                                 </div>
                               </div>
                               {/* Tags */}
-                              <div className="flex gap-12">
+                              <div className="flex gap-12 -ml-4">
                                 {combination.tags.map((tag) => (
                                   <CombinationTag key={tag.name} name={tag.name} status={tag.status} />
                                 ))}
@@ -569,7 +607,7 @@ const MyPage = () => {
                             </div>
 
                             {/* 기기 그리드 */}
-                            <div className="pl-8 mt-24">
+                            <div className="pl-8 mt-24 relative">
                               <div
                                 className={`grid ${columns === 4 ? 'grid-cols-4' : 'grid-cols-3'} gap-x-28 gap-y-12`}
                               >
@@ -589,6 +627,17 @@ const MyPage = () => {
                                   </div>
                                 ))}
                               </div>
+
+                              {/* 그라데이션 - 4열: 9개 이상, 3열: 7개 이상 */}
+                              {devices.length >= (columns === 4 ? 9 : 7) && (
+                                <div
+                                  className="absolute right-0 bottom-0 w-244 h-80 rounded-card pointer-events-none"
+                                  style={{
+                                    background:
+                                      'linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%)',
+                                  }}
+                                />
+                              )}
                             </div>
                           </div>
                         ) : (
@@ -611,7 +660,7 @@ const MyPage = () => {
                                 </div>
                               </div>
                               {/* Tags */}
-                              <div className="flex gap-12">
+                              <div className="flex gap-12 -ml-4">
                                 {combination.tags.map((tag) => (
                                   <CombinationTag key={tag.name} name={tag.name} status={tag.status} />
                                 ))}
@@ -725,6 +774,48 @@ const MyPage = () => {
                     setShowCombinationDeleteModal(false);
                     setDeleteTargetIndex(null);
                   }}
+                  className="w-168 h-52 bg-gray-100 hover:bg-gray-200 rounded-button flex items-center justify-center cursor-pointer transition-colors"
+                >
+                  <span className="font-body-2-sm text-black">취소</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* 조합명 저장 확인 모달 */}
+      {showSaveModal && (
+        <>
+          {/* 배경 오버레이 */}
+          <div
+            className="fixed inset-0 bg-black/50 z-60"
+            onClick={() => setShowSaveModal(false)}
+          />
+          {/* 모달 */}
+          <div className="fixed inset-0 flex items-center justify-center z-70 pointer-events-none">
+            <div
+              className="bg-white rounded-card w-460 px-36 py-44 flex flex-col items-center pointer-events-auto"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* 아이콘 */}
+              <SaveIcon className="w-58 h-58 text-blue-600" />
+
+              {/* 텍스트 */}
+              <p className="font-body-2-r text-black mt-36">
+                조합명을 저장하시겠습니까?
+              </p>
+
+              {/* 버튼 그룹 */}
+              <div className="flex gap-20 mt-60">
+                <button
+                  onClick={handleSaveCombinationName}
+                  className="w-168 h-52 bg-blue-600 hover:bg-blue-500 rounded-button flex items-center justify-center cursor-pointer transition-colors"
+                >
+                  <span className="font-body-2-sm text-white">확인</span>
+                </button>
+                <button
+                  onClick={() => setShowSaveModal(false)}
                   className="w-168 h-52 bg-gray-100 hover:bg-gray-200 rounded-button flex items-center justify-center cursor-pointer transition-colors"
                 >
                   <span className="font-body-2-sm text-black">취소</span>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -6,6 +6,7 @@ import SecondaryButton from '@/components/Button/SecondaryButton';
 import SortDropdown from '@/components/Filter/SortDropdown';
 import CombinationTag from '@/components/Combination/CombinationTag';
 import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
+import RecentlyViewedFloating from '@/components/RecentlyViewed/RecentlyViewedFloating';
 import SettingIcon from '@/assets/icons/setting.svg?react';
 import SupportIcon from '@/assets/icons/support.svg?react';
 import SettingMoreIcon from '@/assets/icons/settingmore.svg?react';
@@ -63,6 +64,7 @@ const MyPage = () => {
   const [editingCombinationName, setEditingCombinationName] = useState('');
   const [showSaveModal, setShowSaveModal] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const sidebarContentRef = useRef<HTMLDivElement>(null);
 
   // 스크롤 감지 (하단 그라데이션용)
   useEffect(() => {
@@ -178,49 +180,61 @@ const MyPage = () => {
           className="flex-shrink-0 pt-64 w-280"
           style={{ marginLeft: 'clamp(80px, calc(80px + (100vw - 1440px) * 0.166667), 160px)' }}
         >
-          {/* MY Page 헤더 */}
-          <div className="flex items-center justify-between h-72">
-            <h1 className="font-heading-2 text-black">MY Page</h1>
-            <div className="flex items-center gap-8">
-              <a
-                href="https://lovely-potassium-7f2.notion.site/2f0c82f125c980fa8fa0d2ef430bbe79?pvs=74"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="w-42 h-42 flex items-center justify-center cursor-pointer hover:opacity-80">
-                <SupportIcon className="w-42 h-42 text-black" />
-              </a>
-              <button
-                onClick={() => navigate('/my/settings/profile')}
-                className="w-44 h-44 flex items-center justify-center cursor-pointer hover:opacity-80"
-              >
-                <SettingIcon className="w-44 h-44 text-black" />
-              </button>
+          {/* 사이드바 콘텐츠 wrapper */}
+          <div ref={sidebarContentRef}>
+            {/* MY Page 헤더 */}
+            <div className="flex items-center justify-between h-72">
+              <h1 className="font-heading-2 text-black">MY Page</h1>
+              <div className="flex items-center gap-8">
+                <a
+                  href="https://lovely-potassium-7f2.notion.site/2f0c82f125c980fa8fa0d2ef430bbe79?pvs=74"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-42 h-42 flex items-center justify-center cursor-pointer hover:opacity-80">
+                  <SupportIcon className="w-42 h-42 text-black" />
+                </a>
+                <button
+                  onClick={() => navigate('/my/settings/profile')}
+                  className="w-44 h-44 flex items-center justify-center cursor-pointer hover:opacity-80"
+                >
+                  <SettingIcon className="w-44 h-44 text-black" />
+                </button>
+              </div>
             </div>
-          </div>
 
-          {/* 프로필 카드 */}
-          <div className="mt-60 h-100 rounded-card border border-blue-300 flex items-center justify-center gap-30">
-            <Logo className="w-48 h-48 flex-shrink-0" />
-            <p className="font-heading-2 text-black">000 님</p>
-          </div>
+            {/* 프로필 카드 */}
+            <div className="mt-60 h-100 rounded-card border border-blue-300 flex items-center justify-center gap-30">
+              <Logo className="w-48 h-48 flex-shrink-0" />
+              <p className="font-heading-2 text-black">000 님</p>
+            </div>
 
-          {/* 사용자 정보 */}
-          <div className="mt-44 flex flex-col gap-16">
-            <div className="flex items-center gap-24">
-              <p className="font-body-2-sm text-black whitespace-nowrap">가입일</p>
-              <p className="font-body-2-r text-black">2023.12.22</p>
-            </div>
-            <div className="flex items-center gap-24">
-              <p className="font-body-2-sm text-black whitespace-nowrap">이메일</p>
-              <p className="font-body-2-r text-black truncate">example@devicelife.com</p>
-            </div>
-            <div className="flex items-center gap-24">
-              <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
-              <div className="flex flex-wrap gap-12 content-start">
-                <RoundedLifestyleTag label="Office" />
+            {/* 사용자 정보 */}
+            <div className="mt-44 flex flex-col gap-16">
+              <div className="flex items-center gap-24">
+                <p className="font-body-2-sm text-black whitespace-nowrap">가입일</p>
+                <p className="font-body-2-r text-black">2023.12.22</p>
+              </div>
+              <div className="flex items-center gap-24">
+                <p className="font-body-2-sm text-black whitespace-nowrap">이메일</p>
+                <p className="font-body-2-r text-black truncate">example@devicelife.com</p>
+              </div>
+              <div className="flex items-center gap-24">
+                <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
+                <div className="flex flex-wrap gap-12 content-start">
+                  <RoundedLifestyleTag label="Office" />
+                </div>
               </div>
             </div>
           </div>
+<<<<<<< HEAD
+=======
+
+          {/* 최근에 본 기기 플로팅 섹션 */}
+          <RecentlyViewedFloating
+            userName="000"
+            sidebarContentRef={sidebarContentRef}
+          />
+>>>>>>> b3657c6 (feat: 마이페이지 좌측 플로팅 구현)
         </aside>
 
         {/* 우측 메인 콘텐츠 */}
@@ -317,8 +331,7 @@ const MyPage = () => {
                           /* 수정 모드: 저장하기 버튼 */
                           <SecondaryButton
                             text="저장하기"
-                            onClick={(e) => {
-                              e?.stopPropagation?.();
+                            onClick={() => {
                               setShowSaveModal(true);
                             }}
                             className="w-150"

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -241,15 +241,12 @@ const MyPage = () => {
               </div>
             </div>
           </div>
-<<<<<<< HEAD
-=======
 
           {/* 최근에 본 기기 플로팅 섹션 */}
           <RecentlyViewedFloating
             userName="000"
             sidebarContentRef={sidebarContentRef}
           />
->>>>>>> b3657c6 (feat: 마이페이지 좌측 플로팅 구현)
         </aside>
 
         {/* 우측 메인 콘텐츠 */}
@@ -320,16 +317,7 @@ const MyPage = () => {
 
                   {/* 조합 카드 */}
                   <div
-<<<<<<< HEAD
-                    onClick={() => {
-                      // 상세보기가 아닐 때, 카드를 클릭하면 상세보기로 진입
-                      if (!isDetailView) {
-                        handleDetailView(index);
-                      }
-                    }}
-=======
                     onClick={() => !isDetailView && editingCombinationIndex !== index && handleDetailView(index)}
->>>>>>> a8799cc (feat: 조합명 수정하기 구현, 저장팝업 구현)
                     className={`rounded-card relative ${
                       isDetailView
                         ? 'bg-blue-100'

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -240,9 +240,9 @@ const MyPage = () => {
                   setDeleteTargetIndex(detailViewIndex);
                   setShowCombinationDeleteModal(true);
                 }}
-                className="w-280 h-72 border-2 border-red-500 rounded-button flex items-center justify-center cursor-pointer hover:bg-red-50 transition-colors"
+                className="w-280 h-52 border-2 border-warning rounded-button flex items-center justify-center cursor-pointer hover:bg-warning/10 transition-colors"
               >
-                <span className="font-body-2-sm text-red-500">조합 삭제하기</span>
+                <span className="font-body-2-sm text-warning">조합 삭제하기</span>
               </button>
             ) : (
               <PrimaryButton
@@ -451,8 +451,13 @@ const MyPage = () => {
                           </div>
                         </div>
 
+                        {/* 안내 텍스트 */}
+                        <p className="px-56 pt-36 font-caption-r text-blue-800">
+                          *마우스를 기기 위에 올려서 기기 상세정보를 확인하실 수도 있습니다.
+                        </p>
+
                         {/* 기기 그리드 (체크박스 포함) */}
-                        <div className="px-56 pt-56 pb-36">
+                        <div className="px-56 pt-36 pb-36">
                           <div
                             className={`grid ${columns === 4 ? 'grid-cols-4' : 'grid-cols-3'} gap-x-28 gap-y-12`}
                           >

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -465,9 +465,16 @@ const MyPage = () => {
                               <div
                                 key={device.id}
                                 onClick={() => window.open(`/devices?productId=${device.id}`, '_blank')}
-                                className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border cursor-pointer hover:shadow-[0_0_8px_rgba(0,0,0,0.15)] transition-shadow ${selectedDevices.includes(device.id) ? 'border-blue-600' : 'border-transparent'}`}
+                                className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow ${selectedDevices.includes(device.id) ? 'border-blue-600' : 'border-transparent'}`}
                               >
-                                <div className="w-64 h-64 bg-gray-200 flex-shrink-0" />
+                                <div className="w-64 h-64 bg-gray-200 flex-shrink-0 relative group/image">
+                                  {/* 호버 오버레이 */}
+                                  <div className="absolute inset-0 bg-black/50 opacity-0 group-hover/image:opacity-100 transition-opacity flex items-center justify-center">
+                                    <span className="bg-white px-8 py-4 rounded-tag font-caption-r text-black">
+                                      보기
+                                    </span>
+                                  </div>
+                                </div>
                                 <div className="flex flex-col gap-4 flex-1">
                                   <div className="flex items-center justify-between">
                                     <p className="font-body-3-sm text-black truncate w-120">

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -291,12 +291,16 @@ const MyPage = () => {
 
                   {/* 조합 카드 */}
                   <div
+<<<<<<< HEAD
                     onClick={() => {
                       // 상세보기가 아닐 때, 카드를 클릭하면 상세보기로 진입
                       if (!isDetailView) {
                         handleDetailView(index);
                       }
                     }}
+=======
+                    onClick={() => !isDetailView && editingCombinationIndex !== index && handleDetailView(index)}
+>>>>>>> a8799cc (feat: 조합명 수정하기 구현, 저장팝업 구현)
                     className={`rounded-card relative ${
                       isDetailView
                         ? 'bg-blue-100'
@@ -307,17 +311,30 @@ const MyPage = () => {
                     {!isDetailView && (
                       <div
                         ref={openMenuIndex === index ? menuRef : null}
-                        className="absolute right-56 top-36"
+                        className={`absolute right-56 ${editingCombinationIndex === index ? 'top-28' : 'top-36'}`}
                       >
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setOpenMenuIndex(openMenuIndex === index ? null : index);
-                          }}
-                          className="cursor-pointer hover:opacity-80"
-                        >
-                          <SettingMoreIcon className="w-36 h-36 text-gray-400" />
-                        </button>
+                        {editingCombinationIndex === index ? (
+                          /* 수정 모드: 저장하기 버튼 */
+                          <SecondaryButton
+                            text="저장하기"
+                            onClick={(e) => {
+                              e?.stopPropagation?.();
+                              setShowSaveModal(true);
+                            }}
+                            className="w-150"
+                          />
+                        ) : (
+                          /* 일반 모드: ... 버튼 */
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setOpenMenuIndex(openMenuIndex === index ? null : index);
+                            }}
+                            className="cursor-pointer hover:opacity-80"
+                          >
+                            <SettingMoreIcon className="w-36 h-36 text-gray-400" />
+                          </button>
+                        )}
 
                         {/* 드롭다운 메뉴 */}
                         {openMenuIndex === index && (
@@ -582,22 +599,36 @@ const MyPage = () => {
                         {hasDevices ? (
                           <div className="px-36 pt-24 pb-36">
                             {/* 조합 정보 (생성일 포함) */}
-                            <div className="flex flex-col gap-24 pl-20 py-24">
-                              {/* 조합 번호 + 생성일 + 조합명 */}
-                              <div className="flex flex-col gap-8">
-                                <div className="flex items-center gap-16">
-                                  <p className="font-body-3-r text-gray-400">{combination.label}</p>
-                                  {combination.createdAt && (
-                                    <p className="font-body-3-r text-gray-400">
-                                      생성일: {combination.createdAt}
-                                    </p>
-                                  )}
+                            <div className="flex flex-col gap-13 pl-20 py-24">
+                              {editingCombinationIndex === index ? (
+                                /* 수정 모드: 인풋박스 + 별 아이콘 */
+                                <div className="flex items-center gap-8 min-h-48">
+                                  <input
+                                    type="text"
+                                    value={editingCombinationName}
+                                    onChange={(e) => setEditingCombinationName(e.target.value)}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="h-52 px-12 border border-blue-600 rounded-button font-body-1-sm text-gray-300 focus:outline-none"
+                                  />
+                                  {combination.isMain && <StarIcon className="w-22 h-22" />}
                                 </div>
-                                <div className="flex items-center gap-8">
-                                  <p className="font-body-1-sm text-black">{combination.name}</p>
-                                  {combination.isMain && <StarIcon className="w-27 h-27" />}
+                              ) : (
+                                /* 일반 모드: 조합 번호 + 생성일 + 조합명 */
+                                <div className="flex flex-col gap-8">
+                                  <div className="flex items-center gap-16">
+                                    <p className="font-body-3-r text-gray-400">{combination.label}</p>
+                                    {combination.createdAt && (
+                                      <p className="font-body-3-r text-gray-400">
+                                        생성일: {combination.createdAt}
+                                      </p>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center gap-8">
+                                    <p className="font-body-1-sm text-black">{combination.name}</p>
+                                    {combination.isMain && <StarIcon className="w-27 h-27" />}
+                                  </div>
                                 </div>
-                              </div>
+                              )}
                               {/* Tags */}
                               <div className="flex gap-12 -ml-4">
                                 {combination.tags.map((tag) => (

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -317,11 +317,11 @@ const MyPage = () => {
 
                   {/* 조합 카드 */}
                   <div
-                    onClick={() => !isDetailView && editingCombinationIndex !== index && handleDetailView(index)}
+                    onClick={() => !isDetailView && editingCombinationIndex !== index && hasDevices && handleDetailView(index)}
                     className={`rounded-card relative ${
                       isDetailView
                         ? 'bg-blue-100'
-                        : 'bg-white shadow-[0_0_10px_rgba(0,0,0,0.1)] cursor-pointer hover:bg-gray-50 transition-colors'
+                        : `bg-white shadow-[0_0_10px_rgba(0,0,0,0.1)] transition-colors ${hasDevices ? 'cursor-pointer hover:bg-gray-50' : ''}`
                     }`}
                   >
                     {/* 일반 모드: Setting More 버튼 + 드롭다운 또는 저장하기 버튼 */}
@@ -383,7 +383,7 @@ const MyPage = () => {
                               }}
                               onMouseEnter={() => setHoveredMenuItem('rename')}
                               onMouseLeave={() => setHoveredMenuItem(null)}
-                              className="relative font-body-1-sm text-black text-left py-12 whitespace-nowrap cursor-pointer border-b border-black/50"
+                              className={`relative font-body-1-sm text-black text-left py-12 whitespace-nowrap cursor-pointer ${hasDevices ? 'border-b border-black/50' : ''}`}
                             >
                               {hoveredMenuItem === 'rename' && (
                                 <div className="absolute -inset-x-4 inset-y-4 bg-gray-100 rounded-button -z-10" />
@@ -391,21 +391,23 @@ const MyPage = () => {
                               조합명 수정하기
                             </button>
 
-                            {/* 자세히보기 */}
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDetailView(index);
-                              }}
-                              onMouseEnter={() => setHoveredMenuItem('detail')}
-                              onMouseLeave={() => setHoveredMenuItem(null)}
-                              className="relative font-body-1-sm text-black text-left py-12 whitespace-nowrap cursor-pointer"
-                            >
-                              {hoveredMenuItem === 'detail' && (
-                                <div className="absolute -inset-x-4 inset-y-4 bg-gray-100 rounded-button -z-10" />
-                              )}
-                              자세히보기
-                            </button>
+                            {/* 자세히보기 - 기기가 있을 때만 표시 */}
+                            {hasDevices && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleDetailView(index);
+                                }}
+                                onMouseEnter={() => setHoveredMenuItem('detail')}
+                                onMouseLeave={() => setHoveredMenuItem(null)}
+                                className="relative font-body-1-sm text-black text-left py-12 whitespace-nowrap cursor-pointer"
+                              >
+                                {hoveredMenuItem === 'detail' && (
+                                  <div className="absolute -inset-x-4 inset-y-4 bg-gray-100 rounded-button -z-10" />
+                                )}
+                                자세히보기
+                              </button>
+                            )}
                           </div>
                         )}
                       </div>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -19,6 +19,7 @@ import CheckboxOnIcon from '@/assets/icons/checkbox_on.svg?react';
 import TrashIcon from '@/assets/icons/trash.svg?react';
 import RemoveIcon from '@/assets/icons/remove.svg?react';
 import SaveIcon from '@/assets/icons/save.svg?react';
+import TopIcon from '@/assets/icons/top.svg?react';
 import Logo from '@/assets/logos/logo.svg?react';
 import { MOCK_COMBINATIONS, MOCK_COMBINATION_DEVICES } from '@/constants/mockData';
 
@@ -63,16 +64,25 @@ const MyPage = () => {
   const [editingCombinationIndex, setEditingCombinationIndex] = useState<number | null>(null);
   const [editingCombinationName, setEditingCombinationName] = useState('');
   const [showSaveModal, setShowSaveModal] = useState(false);
+  const [showTopButton, setShowTopButton] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const sidebarContentRef = useRef<HTMLDivElement>(null);
+  const combinationListRef = useRef<HTMLDivElement>(null);
 
-  // 스크롤 감지 (하단 그라데이션용)
+  // 스크롤 감지 (하단 그라데이션용 + Top 버튼용)
   useEffect(() => {
     const handleScroll = () => {
       const scrollTop = window.scrollY;
       const windowHeight = window.innerHeight;
       const documentHeight = document.documentElement.scrollHeight;
       setIsAtBottom(scrollTop + windowHeight >= documentHeight - 50);
+
+      // 조합 3개 정도 스크롤 시 Top 버튼 표시 (약 800px)
+      if (combinationListRef.current) {
+        const listTop = combinationListRef.current.offsetTop;
+        const thirdCombinationVisible = scrollTop + windowHeight >= listTop + 800;
+        setShowTopButton(thirdCombinationVisible);
+      }
     };
     window.addEventListener('scroll', handleScroll);
     handleScroll();
@@ -168,6 +178,11 @@ const MyPage = () => {
     console.log('저장된 조합명:', editingCombinationName);
     setShowSaveModal(false);
     setEditingCombinationIndex(null);
+  };
+
+  // 맨 위로 스크롤
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
@@ -267,7 +282,7 @@ const MyPage = () => {
           </div>
 
           {/* 조합 카드 목록 */}
-          <div className="mt-76 flex flex-col gap-40">
+          <div ref={combinationListRef} className="mt-76 flex flex-col gap-40">
             {MOCK_COMBINATIONS.map((combination, index) => {
               const devices = MOCK_COMBINATION_DEVICES[combination.id] || [];
               const hasDevices = devices.length > 0;
@@ -744,6 +759,17 @@ const MyPage = () => {
               );
             })}
           </div>
+
+          {/* Top Button - 조합 3개 정도 스크롤 시 표시 */}
+          {showTopButton && (
+            <button
+              onClick={handleScrollToTop}
+              className="fixed right-48 bottom-48 w-48 h-48 flex items-center justify-center cursor-pointer hover:opacity-80 transition-all duration-300"
+              aria-label="맨 위로 이동"
+            >
+              <TopIcon className="w-48 h-48 text-gray-300" />
+            </button>
+          )}
 
           {/* 하단 여백 */}
           <div className="h-268" />

--- a/src/types/recentlyViewed.ts
+++ b/src/types/recentlyViewed.ts
@@ -1,0 +1,9 @@
+// 최근 본 기기 데이터 타입
+export interface RecentlyViewedDevice {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  image: string | null;
+  viewedAt: number;
+}

--- a/src/utils/recentlyViewedStorage.ts
+++ b/src/utils/recentlyViewedStorage.ts
@@ -1,0 +1,53 @@
+import { RECENTLY_VIEWED_DEVICES, RECENTLY_VIEWED_MAX_COUNT } from '@/constants/storageKeys';
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+
+// localStorage를 조작하는 유틸리티 함수
+// 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함
+
+// 최근 본 기기 목록 가져오기
+export const getRecentlyViewedDevices = (): RecentlyViewedDevice[] => {
+  try {
+    const data = localStorage.getItem(RECENTLY_VIEWED_DEVICES);
+    if (!data) return [];
+    return JSON.parse(data) as RecentlyViewedDevice[];
+  } catch {
+    return [];
+  }
+};
+
+// 기기 추가 (가장 최근 것이 맨 앞, 중복 제거, 최대 개수 제한)
+export const addRecentlyViewedDevice = (
+  device: Omit<RecentlyViewedDevice, 'viewedAt'>
+): void => {
+  const devices = getRecentlyViewedDevices();
+
+  // 이미 있는 기기는 제거 (중복 방지)
+  const filteredDevices = devices.filter((d) => d.id !== device.id);
+
+  // 새 기기를 맨 앞에 추가
+  const newDevice: RecentlyViewedDevice = {
+    ...device,
+    viewedAt: Date.now(),
+  };
+
+  const updatedDevices = [newDevice, ...filteredDevices].slice(0, RECENTLY_VIEWED_MAX_COUNT);
+
+  localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(updatedDevices));
+};
+
+// 특정 기기 삭제
+export const removeRecentlyViewedDevice = (deviceId: number): void => {
+  const devices = getRecentlyViewedDevices();
+  const filteredDevices = devices.filter((d) => d.id !== deviceId);
+  localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(filteredDevices));
+};
+
+// 전체 삭제
+export const clearRecentlyViewedDevices = (): void => {
+  localStorage.removeItem(RECENTLY_VIEWED_DEVICES);
+};
+
+// 최근 본 기기 존재 여부
+export const hasRecentlyViewedDevices = (): boolean => {
+  return getRecentlyViewedDevices().length > 0;
+};


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #96

## 🔍 구현한 내용

- 마이페이지 자세히보기 -> 기기 클릭 시 쿼리파라미터 연결 시켰습니다.
- 조합명 수정하기 구현하였습니다. 저장 시 팝업 구현하였습니다.
- 마이페이지 자세히보기 <전체 선택하기> 하단에 문구 추가하였습니다.
- 자세히보기 카드 hover시 border 변화, 카드에 보기 추가하였습니다.
- 마이페이지 좌측 플로팅 메뉴 구현하였습니다.
- 플로팅메뉴  mock으로 추가하였습니다.
- 마이페이지 top button 구현하였습니다.
- 새로 생성한 조합의 경우 자세히보기를 삭제하였습니다.

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
