### PR TITLE
feature: 조합 삭제, 조합에서 기기 삭제, 조합 즐겨찾기 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1564,6 +1565,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -1917,6 +1919,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -2010,6 +2013,7 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2020,6 +2024,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2079,6 +2084,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2330,6 +2336,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2452,6 +2459,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2886,6 +2894,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2946,6 +2955,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4155,6 +4165,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4207,6 +4218,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4251,6 +4263,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4260,6 +4273,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4272,6 +4286,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4595,6 +4610,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4681,6 +4697,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4816,6 +4833,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/apis/combo/deleteCombo.ts
+++ b/src/apis/combo/deleteCombo.ts
@@ -1,0 +1,23 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import type { DeleteComboResponse } from '@/types/combo/combo';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+
+// 조합 삭제
+export const deleteCombo = async (comboId: number): Promise<DeleteComboResponse> => {
+  const { data } = await axiosInstance.delete<DeleteComboResponse>(
+    `/api/combos/${comboId}`
+  );
+  return data;
+};
+
+export const useDeleteCombo = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (comboId: number) => deleteCombo(comboId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey.COMBOS] });
+    },
+  });
+};

--- a/src/apis/combo/deleteComboDevice.ts
+++ b/src/apis/combo/deleteComboDevice.ts
@@ -1,0 +1,29 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import type { DeleteComboDeviceResponse } from '@/types/combo/combo';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+
+// 조합에서 기기 삭제
+export const deleteComboDevice = async (
+  comboId: number,
+  deviceId: number
+): Promise<DeleteComboDeviceResponse> => {
+  const { data } = await axiosInstance.delete<DeleteComboDeviceResponse>(
+    `/api/combos/${comboId}/devices/${deviceId}`
+  );
+  return data;
+};
+
+export const useDeleteComboDevice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ comboId, deviceId }: { comboId: number; deviceId: number }) =>
+      deleteComboDevice(comboId, deviceId),
+    onSuccess: () => {
+      // 조합 목록과 상세 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: [queryKey.COMBOS] });
+      queryClient.invalidateQueries({ queryKey: [queryKey.COMBO_DETAIL] });
+    },
+  });
+};

--- a/src/apis/combo/postComboPin.ts
+++ b/src/apis/combo/postComboPin.ts
@@ -1,0 +1,23 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import type { PostComboPinResponse } from '@/types/combo/combo';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+
+// 조합 Pin 토글
+export const postComboPin = async (comboId: number): Promise<PostComboPinResponse> => {
+  const { data } = await axiosInstance.post<PostComboPinResponse>(
+    `/api/combos/${comboId}/pin`
+  );
+  return data;
+};
+
+export const usePostComboPin = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (comboId: number) => postComboPin(comboId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey.COMBOS] });
+    },
+  });
+};

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -24,6 +24,7 @@ import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePutCombo } from '@/apis/combo/putCombos';
 import { useDeleteCombo } from '@/apis/combo/deleteCombo';
+import { usePostComboPin } from '@/apis/combo/postComboPin';
 import type { ComboListItem } from '@/types/combo/combo';
 
 // 조합 평가 Mock 데이터
@@ -87,6 +88,7 @@ const MyPage = () => {
   const { data: comboDetail } = useGetCombo(detailViewComboId);
   const { mutate: updateCombo, isPending: isUpdating } = usePutCombo();
   const { mutate: deleteCombo, isPending: isDeleting } = useDeleteCombo();
+  const { mutate: togglePin } = usePostComboPin();
 
   // 정렬된 조합 목록
   const sortedCombos = useMemo(() => {
@@ -283,6 +285,20 @@ const MyPage = () => {
       },
       onError: (error) => {
         console.error('조합 삭제 실패:', error);
+      },
+    });
+  };
+
+  // Pin 토글 핸들러
+  const handleTogglePin = (e: React.MouseEvent, comboId: number) => {
+    e.stopPropagation(); // 카드 클릭 이벤트 전파 방지
+
+    togglePin(comboId, {
+      onSuccess: () => {
+        console.log('Pin 상태 변경 성공');
+      },
+      onError: (error) => {
+        console.error('Pin 상태 변경 실패:', error);
       },
     });
   };
@@ -599,7 +615,14 @@ const MyPage = () => {
                             </div>
                             <div className="flex items-center gap-8">
                               <p className="font-heading-3 text-black">{combination.comboName}</p>
-                              {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+                              <StarIcon
+                                onClick={(e) => handleTogglePin(e, combination.comboId)}
+                                className={`w-22 h-22 -mt-2 cursor-pointer transition-opacity ${
+                                  combination.isPinned
+                                    ? 'hover:opacity-80'
+                                    : 'opacity-30 hover:opacity-50'
+                                }`}
+                              />
                             </div>
                           </div>
                         </div>
@@ -812,7 +835,14 @@ const MyPage = () => {
                                       }`}
                                       autoFocus
                                     />
-                                    {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+                                    <StarIcon
+                                      onClick={(e) => handleTogglePin(e, combination.comboId)}
+                                      className={`w-22 h-22 -mt-2 cursor-pointer transition-opacity ${
+                                        combination.isPinned
+                                          ? 'hover:opacity-80'
+                                          : 'opacity-30 hover:opacity-50'
+                                      }`}
+                                    />
                                   </div>
                                   {comboNameError && (
                                     <p className="pl-12 font-body-4-r text-warning">{comboNameError}</p>
@@ -829,7 +859,14 @@ const MyPage = () => {
                                   </div>
                                   <div className="flex items-center gap-8">
                                     <p className="font-body-1-sm text-black">{combination.comboName}</p>
-                                    {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+                                    <StarIcon
+                                      onClick={(e) => handleTogglePin(e, combination.comboId)}
+                                      className={`w-22 h-22 -mt-2 cursor-pointer transition-opacity ${
+                                        combination.isPinned
+                                          ? 'hover:opacity-80'
+                                          : 'opacity-30 hover:opacity-50'
+                                      }`}
+                                    />
                                   </div>
                                 </div>
                               )}
@@ -895,7 +932,14 @@ const MyPage = () => {
                                 </div>
                                 <div className="flex items-center gap-8">
                                   <p className="font-body-1-sm text-black">{combination.comboName}</p>
-                                  {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+                                  <StarIcon
+                                    onClick={(e) => handleTogglePin(e, combination.comboId)}
+                                    className={`w-22 h-22 -mt-2 cursor-pointer transition-opacity ${
+                                      combination.isPinned
+                                        ? 'hover:opacity-80'
+                                        : 'opacity-30 hover:opacity-50'
+                                    }`}
+                                  />
                                 </div>
                               </div>
                               {/* Tags - API에서 태그 정보 제공 시 구현 */}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -23,6 +23,7 @@ import Logo from '@/assets/logos/logo.svg?react';
 import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePutCombo } from '@/apis/combo/putCombos';
+import { useDeleteCombo } from '@/apis/combo/deleteCombo';
 import type { ComboListItem } from '@/types/combo/combo';
 
 // 조합 평가 Mock 데이터
@@ -85,6 +86,7 @@ const MyPage = () => {
   const { data: combos = [], isLoading, isError } = useGetCombos();
   const { data: comboDetail } = useGetCombo(detailViewComboId);
   const { mutate: updateCombo, isPending: isUpdating } = usePutCombo();
+  const { mutate: deleteCombo, isPending: isDeleting } = useDeleteCombo();
 
   // 정렬된 조합 목록
   const sortedCombos = useMemo(() => {
@@ -265,15 +267,24 @@ const MyPage = () => {
 
   // 조합 삭제 핸들러
   const handleDeleteCombination = () => {
-    // API 연동 시 실제 삭제 로직 추가
-    console.log('삭제할 조합 comboId:', deleteTargetComboId);
-    setShowCombinationDeleteModal(false);
-    setDeleteTargetComboId(null);
-    // 자세히보기 모드였다면 일반 모드로 복귀
-    if (detailViewComboId !== null) {
-      setDetailViewComboId(null);
-      setSelectedDevices([]);
-    }
+    if (deleteTargetComboId === null) return;
+
+    deleteCombo(deleteTargetComboId, {
+      onSuccess: () => {
+        console.log('조합 삭제 성공');
+        setShowCombinationDeleteModal(false);
+        setDeleteTargetComboId(null);
+
+        // 자세히보기 모드였다면 일반 모드로 복귀
+        if (detailViewComboId !== null) {
+          setDetailViewComboId(null);
+          setSelectedDevices([]);
+        }
+      },
+      onError: (error) => {
+        console.error('조합 삭제 실패:', error);
+      },
+    });
   };
 
   // 조합명 저장 핸들러
@@ -1002,9 +1013,14 @@ const MyPage = () => {
                 <div className="flex gap-20 mt-60">
                   <button
                     onClick={handleDeleteCombination}
-                    className="w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center cursor-pointer transition-colors"
+                    disabled={isDeleting}
+                    className={`w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center transition-colors ${
+                      isDeleting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                    }`}
                   >
-                    <span className="font-body-2-sm text-white">삭제</span>
+                    <span className="font-body-2-sm text-white">
+                      {isDeleting ? '삭제 중...' : '삭제'}
+                    </span>
                   </button>
                   <button
                     onClick={() => {

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -25,6 +25,7 @@ import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePutCombo } from '@/apis/combo/putCombos';
 import { useDeleteCombo } from '@/apis/combo/deleteCombo';
 import { usePostComboPin } from '@/apis/combo/postComboPin';
+import { useDeleteComboDevice } from '@/apis/combo/deleteComboDevice';
 import type { ComboListItem } from '@/types/combo/combo';
 
 // 조합 평가 Mock 데이터
@@ -89,6 +90,7 @@ const MyPage = () => {
   const { mutate: updateCombo, isPending: isUpdating } = usePutCombo();
   const { mutate: deleteCombo, isPending: isDeleting } = useDeleteCombo();
   const { mutate: togglePin } = usePostComboPin();
+  const { mutate: deleteDevice, isPending: isDeletingDevice } = useDeleteComboDevice();
 
   // 정렬된 조합 목록
   const sortedCombos = useMemo(() => {
@@ -253,11 +255,37 @@ const MyPage = () => {
   };
 
   // 선택된 기기 삭제 핸들러
-  const handleDeleteDevices = () => {
-    // API 연동 시 실제 삭제 로직 추가
-    console.log('Nove ==== 삭제할 기기 ID:', selectedDevices);
-    setSelectedDevices([]);
-    setShowDeleteModal(false);
+  const handleDeleteDevices = async () => {
+    if (!detailViewComboId || selectedDevices.length === 0) return;
+
+    try {
+      // 선택된 모든 기기를 순차적으로 삭제
+      for (const deviceId of selectedDevices) {
+        await new Promise<void>((resolve, reject) => {
+          deleteDevice(
+            { comboId: detailViewComboId, deviceId },
+            {
+              onSuccess: () => {
+                console.log(`기기 ${deviceId} 삭제 성공`);
+                resolve();
+              },
+              onError: (error) => {
+                console.error(`기기 ${deviceId} 삭제 실패:`, error);
+                reject(error);
+              },
+            }
+          );
+        });
+      }
+
+      // 모든 삭제 완료 후
+      setSelectedDevices([]);
+      setShowDeleteModal(false);
+      console.log('모든 기기 삭제 완료');
+    } catch (error) {
+      console.error('기기 삭제 중 오류 발생:', error);
+      // 에러가 발생해도 모달은 닫지 않고 사용자에게 재시도 기회 제공
+    }
   };
 
   // 휴지통 클릭 핸들러
@@ -1009,9 +1037,14 @@ const MyPage = () => {
               <div className="flex gap-20 mt-60">
                 <button
                   onClick={handleDeleteDevices}
-                  className="w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center cursor-pointer transition-colors"
+                  disabled={isDeletingDevice}
+                  className={`w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center transition-colors ${
+                    isDeletingDevice ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                  }`}
                 >
-                  <span className="font-body-2-sm text-white">삭제</span>
+                  <span className="font-body-2-sm text-white">
+                    {isDeletingDevice ? '삭제 중...' : '삭제'}
+                  </span>
                 </button>
                 <button
                   onClick={() => setShowDeleteModal(false)}

--- a/src/types/combo/combo.ts
+++ b/src/types/combo/combo.ts
@@ -71,3 +71,7 @@ export type DeleteComboResponse = CommonResponse<DeleteComboResult>;
 // 조합 Pin 응답 타입
 export type PostComboPinResult = null;
 export type PostComboPinResponse = CommonResponse<PostComboPinResult>;
+
+// 조합에서 기기 삭제 응답 타입
+export type DeleteComboDeviceResult = null;
+export type DeleteComboDeviceResponse = CommonResponse<DeleteComboDeviceResult>;

--- a/src/types/combo/combo.ts
+++ b/src/types/combo/combo.ts
@@ -63,3 +63,7 @@ export type PostComboDeviceRequest = {
 
 export type PostComboDeviceResult = ComboDetail;
 export type PostComboDeviceResponse = CommonResponse<PostComboDeviceResult>;
+
+// 조합 삭제 응답 타입
+export type DeleteComboResult = null;
+export type DeleteComboResponse = CommonResponse<DeleteComboResult>;

--- a/src/types/combo/combo.ts
+++ b/src/types/combo/combo.ts
@@ -67,3 +67,7 @@ export type PostComboDeviceResponse = CommonResponse<PostComboDeviceResult>;
 // 조합 삭제 응답 타입
 export type DeleteComboResult = null;
 export type DeleteComboResponse = CommonResponse<DeleteComboResult>;
+
+// 조합 Pin 응답 타입
+export type PostComboPinResult = null;
+export type PostComboPinResponse = CommonResponse<PostComboPinResult>;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #107 

## 🔍 구현한 내용

조합 관리 추가 API 연동 완료


1. 조합 삭제
2. 조합 즐겨찾기 토글
3. 조합에서 기기 삭제


## 1. 조합 삭제 (DELETE /api/combos/{comboId})

### API 명세
- **설명**: 본인 소유 조합 삭제
- **응답**: `{ "result": null }`
- **에러**: 403 (권한 없음), 404 (조합 없음)

### 구현 파일
- **API 함수 및 Hook**: `src/apis/combo/deleteCombo.ts`
- **타입 정의**: `src/types/combo/combo.ts`
- **사용처**: `MyPage.tsx` - 드롭다운 메뉴 > "삭제하기" / 자세히보기 모드 > "조합 삭제하기"

### 주요 기능

- **삭제 확인 모달**: "'{조합명}'을 삭제하시겠습니까?" 메시지 표시
- **로딩 상태**: `isPending`으로 삭제 중 버튼 비활성화 + "삭제 중..." 표시
- **자동 갱신**: `invalidateQueries`로 삭제 후 조합 목록 자동 새로고침
- **모드 복귀**: 자세히보기 모드에서 삭제 시 일반 모드로 자동 복귀
- **에러 처리**: 삭제 실패 시 콘솔 에러 로그 출력



## 2. 조합 즐겨찾기 토글 (POST /api/combos/{comboId}/pin)

### API 명세
- **설명**: 조합 Pin/Unpin 상태 토글 (최대 3개까지 Pin 가능)
- **기능**: Pin ↔ Unpin 전환
- **응답**: `{ "result": null }`
- **에러**: 403 (권한 없음), 404 (조합 없음)

### 구현 파일

- **API 함수 및 Hook**: `src/apis/combo/postComboPin.ts`
- **타입 정의**: `src/types/combo/combo.ts`
- **사용처**: `MyPage.tsx` - 4곳의 StarIcon
  - 상세보기 모드: 조합명 옆
  - 수정 모드: 인풋 옆
  - 일반 모드: 조합명 옆
  - 기기 없는 조합: 조합명 옆

### 주요 기능
- **시각적 구분**:
  - **Pin된 상태**: opacity 1.0 (진한 황금색 별)
  - **Pin 안된 상태**: opacity 0.3 (흐린 별)
- **항상 표시**: 모든 조합에 별 아이콘 표시 (조건부 렌더링 제거)
- **Hover 효과**: opacity 변화로 클릭 가능함을 암시
  - Pin된 별: hover 시 opacity 0.8
  - Pin 안된 별: hover 시 opacity 0.5
- **이벤트 전파 방지**: `e.stopPropagation()`으로 카드 클릭 이벤트 차단
- **정렬 연동**: Pin된 조합이 항상 상단에 고정 (기존 정렬 로직 활용)
- **자동 갱신**: `invalidateQueries`로 상태 변경 후 자동 재정렬
- **트랜지션**: `transition-opacity`로 부드러운 상태 변화



## 3. 조합에서 기기 삭제 (DELETE /api/combos/{comboId}/devices/{deviceId})

### API 명세
- **설명**: 조합에서 기기 제거 (본인 조합만 가능)
- **응답**: `{ "result": null }`
- **에러**: 400 (기기 없음), 403 (권한 없음), 404 (조합 없음)

### 구현 파일
- **API 함수 및 Hook**: `src/apis/combo/deleteComboDevice.ts`
- **타입 정의**: `src/types/combo/combo.ts`
- **사용처**: `MyPage.tsx` - 자세히보기 모드

### 주요 기능
- **기기 선택**: 체크박스로 1개 이상 선택 가능
- **전체 선택**: "전체 선택하기" 버튼으로 일괄 선택/해제 토글
- **삭제 확인 모달**: "선택한 기기들을 삭제하시겠습니까?" 메시지 표시
- **순차 삭제**: 선택된 여러 기기를 `for` 루프로 순차 처리
  - Promise를 사용하여 각 기기 삭제 완료를 기다림
  - 삭제 실패 시 전체 프로세스 중단
- **로딩 상태**: `isPending`으로 삭제 중 버튼 비활성화 + "삭제 중..." 표시
- **에러 처리**:
  - 삭제 실패 시 모달을 닫지 않고 유지 (재시도 기회 제공)
  - 콘솔에 각 기기별 성공/실패 로그 출력
- **자동 갱신**:
  - `invalidateQueries(queryKey.COMBOS)` - 조합 목록 새로고침
  - `invalidateQueries(queryKey.COMBO_DETAIL)` - 조합 상세 정보 새로고침
- **UI 업데이트**: 삭제 완료 후 체크박스 선택 초기화 및 모달 자동 닫힘

---

## 📸 스크린샷 or 실행 영상



## 📢 리뷰어에게

### 테스트 체크리스트

#### 조합 삭제
- 드롭다운 메뉴에서 "삭제하기" 클릭 시 모달 표시
- 자세히보기 모드에서 "조합 삭제하기" 버튼 클릭 시 모달 표시
- 모달에서 조합명이 정상적으로 표시됨
- "삭제" 버튼 클릭 시 조합 삭제 및 목록 자동 새로고침
- 삭제 중 버튼 비활성화 및 "삭제 중..." 표시
- 자세히보기 모드에서 삭제 시 일반 모드로 복귀

#### 조합 즐겨찾기
- 별 아이콘이 모든 조합에 표시됨
- Pin 안된 조합: 흐린 별 (opacity 0.3)
- Pin된 조합: 진한 별 (opacity 1.0)
- 별 아이콘 클릭 시 Pin 상태 토글
- 별 클릭 시 카드 클릭 이벤트 발생하지 않음
- Pin 토글 후 목록 자동 재정렬 (Pin된 조합이 상단으로 이동)
- Hover 시 opacity 변화 확인
- 4곳의 StarIcon 모두 클릭 가능 (상세보기/수정/일반/빈조합 모드)

#### 조합에서 기기 삭제
- 자세히보기 모드 진입 시 체크박스 표시
- 개별 기기 체크박스 선택/해제 가능
- "전체 선택하기" 버튼으로 전체 선택/해제
- 선택된 기기가 있을 때만 휴지통 아이콘 활성화
- 휴지통 클릭 시 삭제 확인 모달 표시
- "삭제" 버튼 클릭 시 선택된 모든 기기 삭제
- 삭제 중 버튼 비활성화 및 "삭제 중..." 표시
- 삭제 완료 후 체크박스 선택 초기화 및 모달 닫힘
- 삭제 후 조합 상세 정보 자동 갱신
- 여러 기기 선택 후 삭제 시 순차적으로 모두 삭제됨
