### PR TITLE
feature: 온보딩 미완료 유저 로직 구현

### DIFF
--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -63,7 +63,7 @@ const CombinationDeviceCard = ({
         <div className="flex flex-col gap-8">
           <div className="flex items-center gap-8">
             <p className="font-body-1-sm text-black">{combination.comboName}</p>
-            {combination.isPinned && <StarIcon className="w-22 h-22" />}
+            {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
           </div>
         </div>
         {/* Tags */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/constants/devices';
 import { MOCK_PRODUCTS } from '@/constants/mockData';
 import { ROUTES } from '@/constants/routes';
-import { type AuthStatus, type ModalView } from '@/types/devices';
+import { type ModalView } from '@/types/devices';
 import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePostComboDevice } from '@/apis/combo/postComboDevices';
@@ -45,9 +45,6 @@ const DeviceSearchPage = () => {
 
   // 온보딩 완료 여부 확인 (로딩 중에는 false로 기본 처리)
   const hasOnboarding = isProfileLoading ? false : hasCompletedOnboarding(userProfile);
-
-  // 기존 코드와의 호환성을 위한 authStatus
-  const authStatus: AuthStatus = isLoggedIn ? 'login' : 'logout';
 
   const [modalView, setModalView] = useState<ModalView>('device');
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -540,7 +540,7 @@ const DeviceSearchPage = () => {
                             {/* 조합명 + 대표조합 star */}
                             <div className="flex items-center gap-8">
                               <p className="font-body-1-sm text-black">{combo.comboName}</p>
-                              {combo.isPinned && <StarIcon className="w-22 h-22" />}
+                              {combo.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
                             </div>
                           </div>
                           {/* 기기 수 + 총 가격 */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import GNB from '@/components/Home/GNB';
 import ProductCard from '@/components/ProductCard/ProductCard';
 import PrimaryButton from '@/components/Button/PrimaryButton';
@@ -24,17 +24,31 @@ import {
   SCROLL_CONSTANTS,
 } from '@/constants/devices';
 import { MOCK_PRODUCTS } from '@/constants/mockData';
+import { ROUTES } from '@/constants/routes';
 import { type AuthStatus, type ModalView } from '@/types/devices';
 import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePostComboDevice } from '@/apis/combo/postComboDevices';
+import { useGetUserProfile } from '@/apis/mypage/getUserProfile';
+import { hasAuthTokens, hasCompletedOnboarding } from '@/utils/auth/authStorage';
 
 const DeviceSearchPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedProductId = searchParams.get('productId');
+  const navigate = useNavigate();
 
-  // 추후 Zustand/Context에서 인증 상태 가져오기
-  const [authStatus] = useState<AuthStatus>('login'); // 테스트로 login으로 변경. 추후 logout으로 변경.
+  // 로그인 상태 확인
+  const isLoggedIn = hasAuthTokens();
+
+  // 사용자 프로필 조회 (로그인 시에만 자동 실행)
+  const { data: userProfile, isLoading: isProfileLoading } = useGetUserProfile();
+
+  // 온보딩 완료 여부 확인 (로딩 중에는 false로 기본 처리)
+  const hasOnboarding = isProfileLoading ? false : hasCompletedOnboarding(userProfile);
+
+  // 기존 코드와의 호환성을 위한 authStatus
+  const authStatus: AuthStatus = isLoggedIn ? 'login' : 'logout';
+
   const [modalView, setModalView] = useState<ModalView>('device');
 
   // API hooks
@@ -79,11 +93,6 @@ const DeviceSearchPage = () => {
 
   /* 내 조합에 담기 */
   const handleAddToCombination = () => {
-    if (authStatus === 'logout') {
-      // 로그인 페이지로 이동
-      return;
-    }
-
     // 조합이 1개면 바로 저장
     if (combos.length === 1 && selectedProductId) {
       addDeviceToCombo(
@@ -109,6 +118,37 @@ const DeviceSearchPage = () => {
     // 조합이 2개 이상이면 선택 모달 표시
     setModalView('combination');
   };
+
+  /* 버튼 텍스트 및 핸들러 결정 */
+  const getAddToCombinationConfig = () => {
+    // Case 1: 로그아웃 상태
+    if (!isLoggedIn) {
+      return {
+        text: '로그인하고 내 조합에 담기',
+        handler: () => {
+          navigate(ROUTES.auth.login);
+        },
+      };
+    }
+
+    // Case 2: 로그인했지만 온보딩 미완료
+    if (!hasOnboarding) {
+      return {
+        text: '맞춤 설정하고 담기',
+        handler: () => {
+          navigate(ROUTES.auth.onboarding.lifestyle);
+        },
+      };
+    }
+
+    // Case 3: 로그인 + 온보딩 완료
+    return {
+      text: '내 조합에 담기',
+      handler: handleAddToCombination,
+    };
+  };
+
+  const addToCombinationConfig = getAddToCombinationConfig();
 
   /* 조합 선택 - 기기 리스트 보기 */
   const handleSelectCombination = (combinationId: number) => {
@@ -400,8 +440,9 @@ const DeviceSearchPage = () => {
 
                       {/* Button */}
                       <PrimaryButton
-                        text={authStatus === 'logout' ? '로그인하고 내 조합에 담기' : '내 조합에 담기'}
-                        onClick={handleAddToCombination}
+                        text={addToCombinationConfig.text}
+                        onClick={addToCombinationConfig.handler}
+                        disabled={isProfileLoading}
                         className="w-full bg-blue-500 hover:bg-blue-400 transition-colors"
                       />
                     </div>

--- a/src/utils/auth/authStorage.ts
+++ b/src/utils/auth/authStorage.ts
@@ -1,4 +1,5 @@
 import { ACCESS_TOKEN, REFRESH_TOKEN} from '@/constants/tokenKey';
+import type { UserProfileResult } from '@/types/mypage/user';
 
 // localStorage를 조작하는 유틸리티 함수
 // 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함
@@ -36,4 +37,12 @@ export const hasAuthTokens = (): boolean => {
   const accessToken = getAccessToken();
   const refreshToken = getRefreshToken();
   return !!(accessToken && refreshToken);
+};
+
+// 온보딩 완료 여부 확인
+// lifestyleList가 비어있지 않으면 온보딩 완료로 판단
+export const hasCompletedOnboarding = (
+  userProfile: UserProfileResult | undefined
+): boolean => {
+  return !!(userProfile?.lifestyleList && userProfile.lifestyleList.length > 0);
 };


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #118 

## 🔍 구현한 내용

- 온보딩 과정 중 이탈한 유저에 대하여 로직 구현하였습니다. 
  기기 검색 페이지에서 제품을 선택할 시 버튼이 맞춤 설정하고 담기로 구현되어있습니다.

  feat: 온보딩 미완료 사용자 케이스 처리 및 UI 개선                                                                               
  


  작업 내용 요약

  1. 온보딩 미완료 사용자 케이스 추가 


  기존에는 로그인/로그아웃 2가지 케이스만 처리했으나, 
  로그인했지만 온보딩을 완료하지 않은 사용자(GNB 이동, 이탈 등)에 대한 처리가 필요했습니다.

  구현 내용

  사용자 케이스별 버튼 동작:
  - 로그아웃 상태: "로그인하고 내 조합에 담기" → 로그인 페이지로 이동
  - 로그인 + 온보딩 미완료: "맞춤 설정하고 담기" → 온보딩 라이프스타일 선택 페이지로 이동
  - 로그인 + 온보딩 완료: "내 조합에 담기" → 기존 조합 담기 로직 실행

  변경 파일

  - src/utils/auth/authStorage.ts
    - hasCompletedOnboarding() 헬퍼 함수 추가
    - userProfile.lifestyleList로 온보딩 완료 여부 판단
  - src/pages/devices/DeviceSearchPage.tsx
    - 하드코딩된 authStatus 제거 → 동적 인증/온보딩 상태 체크로 변경
    - hasAuthTokens() + useGetUserProfile() 조합으로 로그인 상태 확인
    - getAddToCombinationConfig() 함수로 3가지 케이스 처리
    - 프로필 로딩 중 버튼 disabled 처리

  2. 별 아이콘 수직 정렬 수정 (design)

  배경

  조합 리스트와 기기 전체보기 모달에서 별 아이콘이 텍스트보다 살짝 아래에 위치하여 Mypage와 일관성이 없었습니다.

  구현 내용

  Mypage와 동일하게 -mt-2 클래스를 추가하여 별 아이콘을 2px 위로 올려 텍스트와 정렬했습니다.



## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게

  테스트 시나리오

  온보딩 케이스 테스트

  1. 로그아웃 상태: "로그인하고 내 조합에 담기" 버튼 → /auth/login 이동 확인
  2. 온보딩 미완료: "맞춤 설정하고 담기" 버튼 → /auth/onboarding/lifestyle 이동 확인
  3. 온보딩 완료: "내 조합에 담기" 버튼 → 조합 선택/저장 정상 동작 확인