### PR TITLE
feat: 라이프스타일 api 연동

### DIFF
--- a/src/apis/lifestyle/getLifestyleDevice.ts
+++ b/src/apis/lifestyle/getLifestyleDevice.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import { useQuery } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+
+import type {
+  LifestyleDeviceResponse,
+  LifestyleDeviceResult,
+  LifestyleTagKey,
+} from '@/types/lifestyle/lifestyle';
+
+export const getLifestyleDevice = async (
+  tagKey: LifestyleTagKey
+): Promise<LifestyleDeviceResult | null> => {
+  const { data } = await axiosInstance.get<LifestyleDeviceResponse>('/api/lifestyle/featured', {
+    params: { tagKey },
+  });
+
+  return data.result ?? null;
+};
+
+export const useGetLifestyleDevice = (tagKey: LifestyleTagKey) => {
+  return useQuery<LifestyleDeviceResult | null>({
+    queryKey: [queryKey.LIFESTYLE_DEVICE, tagKey],
+    queryFn: () => getLifestyleDevice(tagKey),
+    enabled: !!tagKey,
+  });
+};

--- a/src/apis/lifestyle/getLifestyleDevice.ts
+++ b/src/apis/lifestyle/getLifestyleDevice.ts
@@ -2,27 +2,24 @@ import { axiosInstance } from '@/apis/axios/axios';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
 
-import type {
-  LifestyleDeviceResponse,
-  LifestyleDeviceResult,
-  LifestyleTagKey,
-} from '@/types/lifestyle/lifestyle';
+import type { LifestyleDeviceResponse, LifestyleTagKey } from '@/types/lifestyle/lifestyle';
 
 export const getLifestyleDevice = async (
   tagKey: LifestyleTagKey
-): Promise<LifestyleDeviceResult | null> => {
+): Promise<LifestyleDeviceResponse> => {
   const { data } = await axiosInstance.get<LifestyleDeviceResponse>('/api/lifestyle/featured', {
     params: { tagKey },
   });
 
-  return data.result ?? null;
+  return data;
 };
 
 export const useGetLifestyleDevice = (tagKey: LifestyleTagKey) => {
-  return useQuery<LifestyleDeviceResult | null>({
+  return useQuery<LifestyleDeviceResponse>({
     queryKey: [queryKey.LIFESTYLE_DEVICE, tagKey],
     queryFn: () => getLifestyleDevice(tagKey),
     enabled: !!tagKey,
     staleTime: 1000 * 60 * 5,
+    placeholderData: (prev) => prev,
   });
 };

--- a/src/apis/lifestyle/getLifestyleDevice.ts
+++ b/src/apis/lifestyle/getLifestyleDevice.ts
@@ -23,5 +23,6 @@ export const useGetLifestyleDevice = (tagKey: LifestyleTagKey) => {
     queryKey: [queryKey.LIFESTYLE_DEVICE, tagKey],
     queryFn: () => getLifestyleDevice(tagKey),
     enabled: !!tagKey,
+    staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/components/Lifestyle/DeviceSummaryCard.tsx
+++ b/src/components/Lifestyle/DeviceSummaryCard.tsx
@@ -27,7 +27,13 @@ const DeviceSummaryCard = ({ device }: Props) => {
           {device?.releaseDate ?? '-'}
         </p>
         <p className="font-caption-r text-gray-300 w-108 whitespace-nowrap">
-          {device?.price ?? '-'}
+          {device?.price != null
+            ? new Intl.NumberFormat('ko-KR', {
+                style: 'currency',
+                currency: 'KRW',
+                maximumFractionDigits: 0,
+              }).format(device.price)
+            : '-'}
         </p>
       </div>
     </div>

--- a/src/components/Lifestyle/DeviceSummaryCard.tsx
+++ b/src/components/Lifestyle/DeviceSummaryCard.tsx
@@ -1,16 +1,34 @@
-const DeviceSummaryCard = () => {
+import type { LifestyleDevice } from '@/types/lifestyle/lifestyle';
+
+type Props = {
+  device?: LifestyleDevice;
+};
+
+const DeviceSummaryCard = ({ device }: Props) => {
   return (
     <div className="device-card flex items-center p-8 gap-8 rounded-button bg-white border-shadow-gray w-180 shrink-0">
-      <div className="w-48 h-48 bg-gray-200 shrink-0" />
+      <div className="w-48 h-48 bg-gray-200 shrink-0 overflow-hidden">
+        {device?.imageUrl ? (
+          <img
+            src={device.imageUrl}
+            alt={device.displayName}
+            className="w-full h-full object-cover"
+            draggable={false}
+          />
+        ) : null}
+      </div>
       <div className="flex flex-col gap-4 min-w-0">
-        {/* TODO: API 연동 */}
         <div className="w-108 overflow-hidden">
           <p className="device-name font-caption-sm text-black whitespace-nowrap">
-            SteelSeries Arctis Nova Pro
+            {device?.displayName ?? '-'}
           </p>
         </div>
-        <p className="font-caption-r text-gray-300 w-108 whitespace-nowrap">2024-05-15</p>
-        <p className="font-caption-r text-gray-300 w-108 whitespace-nowrap">1499000</p>
+        <p className="font-caption-r text-gray-300 w-108 whitespace-nowrap">
+          {device?.releaseDate ?? '-'}
+        </p>
+        <p className="font-caption-r text-gray-300 w-108 whitespace-nowrap">
+          {device?.price ?? '-'}
+        </p>
       </div>
     </div>
   );

--- a/src/constants/lifestyle.ts
+++ b/src/constants/lifestyle.ts
@@ -1,0 +1,36 @@
+import Office from '@/assets/images/lifestyle/office.jpg';
+import Developer from '@/assets/images/lifestyle/developer.jpg';
+import Game from '@/assets/images/lifestyle/game.jpg';
+import Study from '@/assets/images/lifestyle/study.jpg';
+import VideoEditing from '@/assets/images/lifestyle/video-editing.jpg';
+import Tour from '@/assets/images/lifestyle/tour.jpg';
+import type { LifestyleTagKey } from '@/types/lifestyle/lifestyle';
+
+export const LIFESTYLE_TAGS = [
+  'Office',
+  'Developer',
+  'Game',
+  'Study',
+  'Video-editing',
+  'Tour/portability',
+] as const;
+
+export type LifestyleLabel = (typeof LIFESTYLE_TAGS)[number];
+
+export const LIFESTYLE_TAG_IMAGE_MAP: Record<LifestyleLabel, string> = {
+  Office,
+  Developer,
+  Game,
+  Study,
+  'Video-editing': VideoEditing,
+  'Tour/portability': Tour,
+};
+
+export const LIFESTYLE_LABEL_TO_TAGKEY: Record<LifestyleLabel, LifestyleTagKey> = {
+  Office: 'Office',
+  Developer: 'Developer',
+  Game: 'Game',
+  Study: 'Study',
+  'Video-editing': 'Video-editing',
+  'Tour/portability': 'Tour',
+};

--- a/src/constants/lifestyle.ts
+++ b/src/constants/lifestyle.ts
@@ -6,31 +6,49 @@ import VideoEditing from '@/assets/images/lifestyle/video-editing.jpg';
 import Tour from '@/assets/images/lifestyle/tour.jpg';
 import type { LifestyleTagKey } from '@/types/lifestyle/lifestyle';
 
-export const LIFESTYLE_TAGS = [
-  'Office',
-  'Developer',
-  'Game',
-  'Study',
-  'Video-editing',
-  'Tour/portability',
-] as const;
+export const LIFESTYLE_CONFIG = {
+  Office: {
+    image: Office,
+    tagKey: 'Office',
+  },
+  Developer: {
+    image: Developer,
+    tagKey: 'Developer',
+  },
+  Game: {
+    image: Game,
+    tagKey: 'Game',
+  },
+  Study: {
+    image: Study,
+    tagKey: 'Study',
+  },
+  'Video-editing': {
+    image: VideoEditing,
+    tagKey: 'Video-editing',
+  },
+  'Tour/portability': {
+    image: Tour,
+    tagKey: 'Tour',
+  },
+} as const satisfies Record<
+  string,
+  {
+    image: string;
+    tagKey: LifestyleTagKey;
+  }
+>;
 
-export type LifestyleLabel = (typeof LIFESTYLE_TAGS)[number];
+export type LifestyleLabel = keyof typeof LIFESTYLE_CONFIG;
 
-export const LIFESTYLE_TAG_IMAGE_MAP: Record<LifestyleLabel, string> = {
-  Office,
-  Developer,
-  Game,
-  Study,
-  'Video-editing': VideoEditing,
-  'Tour/portability': Tour,
-};
+export const LIFESTYLE_TAGS = Object.keys(LIFESTYLE_CONFIG) as LifestyleLabel[];
 
-export const LIFESTYLE_LABEL_TO_TAGKEY: Record<LifestyleLabel, LifestyleTagKey> = {
-  Office: 'Office',
-  Developer: 'Developer',
-  Game: 'Game',
-  Study: 'Study',
-  'Video-editing': 'Video-editing',
-  'Tour/portability': 'Tour',
-};
+// label -> image
+export const LIFESTYLE_TAG_IMAGE_MAP = Object.fromEntries(
+  Object.entries(LIFESTYLE_CONFIG).map(([label, { image }]) => [label, image])
+) as Record<LifestyleLabel, string>;
+
+// label -> tagkey
+export const LIFESTYLE_LABEL_TO_TAGKEY = Object.fromEntries(
+  Object.entries(LIFESTYLE_CONFIG).map(([label, { tagKey }]) => [label, tagKey])
+) as Record<LifestyleLabel, LifestyleTagKey>;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -7,4 +7,5 @@ export const queryKey = {
   TAGS: 'tags',
   COMBOS: 'combos',
   COMBO_DETAIL: 'combo',
+  LIFESTYLE_DEVICE: 'lifestyle_device'
 } as const;

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -1,72 +1,54 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ROTATION_MS, TRANSITION_MS, USER_INTERACTION_PAUSE_MS } from '@/constants/time';
 import LifestyleTag from '@/components/Lifestyle/LifestyleTag';
-import Office from '@/assets/images/lifestyle/office.jpg';
-import Developer from '@/assets/images/lifestyle/developer.jpg';
-import Game from '@/assets/images/lifestyle/game.jpg';
-import Study from '@/assets/images/lifestyle/study.jpg';
-import VideoEditing from '@/assets/images/lifestyle/video-editing.jpg';
-import Tour from '@/assets/images/lifestyle/tour.jpg';
 import DeviceSummaryCard from '@/components/Lifestyle/DeviceSummaryCard';
 import { useAutoRotate } from '@/hooks/useAutoRotate';
 import { useCrossfadeImage } from '@/hooks/useCrossfadeImage';
 import { nextInArray } from '@/utils/nextInArray';
 import { useGetLifestyleDevice } from '@/apis/lifestyle/getLifestyleDevice';
 import type { LifestyleTagKey } from '@/types/lifestyle/lifestyle';
-
-const TAGS = ['Office', 'Developer', 'Game', 'Study', 'Video-editing', 'Tour/portability'] as const;
-type Tag = (typeof TAGS)[number];
-
-const TAG_IMAGE_MAP: Record<Tag, string> = {
-  Office,
-  Developer,
-  Game,
-  Study,
-  'Video-editing': VideoEditing,
-  'Tour/portability': Tour,
-};
-
-const LABEL_TO_TAGKEY: Record<Tag, LifestyleTagKey> = {
-  Office: 'Office',
-  Developer: 'Developer',
-  Game: 'Game',
-  Study: 'Study',
-  'Video-editing': 'Video-editing',
-  'Tour/portability': 'Tour',
-};
+import {
+  LIFESTYLE_TAGS,
+  type LifestyleLabel,
+  LIFESTYLE_TAG_IMAGE_MAP,
+  LIFESTYLE_LABEL_TO_TAGKEY,
+} from '@/constants/lifestyle';
 
 const LifestylePage = () => {
-  const [selectedLabel, setSelectedLabel] = useState<Tag>(TAGS[0]);
+  const [selectedLabel, setSelectedLabel] = useState<LifestyleLabel>(LIFESTYLE_TAGS[0]);
   const [isAutoRotate, setIsAutoRotate] = useState(true);
   const [isPaused, setIsPaused] = useState(false);
-  const selectedTagKey = useMemo(() => LABEL_TO_TAGKEY[selectedLabel], [selectedLabel]);
+  const selectedTagKey = useMemo<LifestyleTagKey>(
+    () => LIFESTYLE_LABEL_TO_TAGKEY[selectedLabel],
+    [selectedLabel]
+  );
   const { data } = useGetLifestyleDevice(selectedTagKey);
   const isSuccess = data?.success === true;
   const lifestyleResult = isSuccess ? data?.result : null;
-  
+
   const devices = useMemo(() => {
     const list = lifestyleResult?.devices ?? [];
     return [...list].sort((a, b) => a.slot - b.slot);
   }, [lifestyleResult]);
 
-
-  const targetSrc = useMemo(() => TAG_IMAGE_MAP[selectedLabel], [selectedLabel]);
+  const targetSrc = useMemo(() => LIFESTYLE_TAG_IMAGE_MAP[selectedLabel], [selectedLabel]);
   const { currentSrc, nextSrc, isNextVisible } = useCrossfadeImage(targetSrc, {
     transitionMs: TRANSITION_MS,
   });
 
-  const getNextTag = useCallback((prev: Tag) => nextInArray(TAGS, prev), []);
+  const getNextTag = useCallback((prev: LifestyleLabel) => nextInArray(LIFESTYLE_TAGS, prev), []);
+
   const resumeTimerRef = useRef<number | null>(null);
   const resumeAtRef = useRef<number | null>(null);
 
-  useAutoRotate<Tag>({
+  useAutoRotate<LifestyleLabel>({
     enabled: isAutoRotate && !isPaused,
     intervalMs: ROTATION_MS,
     setValue: setSelectedLabel,
     getNext: getNextTag,
   });
 
-  const handleClickTag = (label: Tag) => {
+  const handleClickTag = (label: LifestyleLabel) => {
     const now = Date.now();
     setSelectedLabel(label);
     setIsAutoRotate(false);
@@ -91,7 +73,7 @@ const LifestylePage = () => {
       <div className="w-full flex justify-center">
         <div className="w-1100 flex items-stretch">
           <div className="flex flex-col gap-16 min-[1441px]:gap-20">
-            {TAGS.map((label) => (
+            {LIFESTYLE_TAGS.map((label) => (
               <LifestyleTag
                 key={label}
                 label={label}

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -40,11 +40,15 @@ const LifestylePage = () => {
   const [isAutoRotate, setIsAutoRotate] = useState(true);
   const [isPaused, setIsPaused] = useState(false);
   const selectedTagKey = useMemo(() => LABEL_TO_TAGKEY[selectedLabel], [selectedLabel]);
-  const { data: lifestyleResult } = useGetLifestyleDevice(selectedTagKey);
+  const { data } = useGetLifestyleDevice(selectedTagKey);
+  const isSuccess = data?.success === true;
+  const lifestyleResult = isSuccess ? data?.result : null;
+  
   const devices = useMemo(() => {
     const list = lifestyleResult?.devices ?? [];
     return [...list].sort((a, b) => a.slot - b.slot);
   }, [lifestyleResult]);
+
 
   const targetSrc = useMemo(() => TAG_IMAGE_MAP[selectedLabel], [selectedLabel]);
   const { currentSrc, nextSrc, isNextVisible } = useCrossfadeImage(targetSrc, {

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -11,9 +11,10 @@ import DeviceSummaryCard from '@/components/Lifestyle/DeviceSummaryCard';
 import { useAutoRotate } from '@/hooks/useAutoRotate';
 import { useCrossfadeImage } from '@/hooks/useCrossfadeImage';
 import { nextInArray } from '@/utils/nextInArray';
+import { useGetLifestyleDevice } from '@/apis/lifestyle/getLifestyleDevice';
+import type { LifestyleTagKey } from '@/types/lifestyle/lifestyle';
 
 const TAGS = ['Office', 'Developer', 'Game', 'Study', 'Video-editing', 'Tour/portability'] as const;
-
 type Tag = (typeof TAGS)[number];
 
 const TAG_IMAGE_MAP: Record<Tag, string> = {
@@ -25,15 +26,31 @@ const TAG_IMAGE_MAP: Record<Tag, string> = {
   'Tour/portability': Tour,
 };
 
+const LABEL_TO_TAGKEY: Record<Tag, LifestyleTagKey> = {
+  Office: 'Office',
+  Developer: 'Developer',
+  Game: 'Game',
+  Study: 'Study',
+  'Video-editing': 'Video-editing',
+  'Tour/portability': 'Tour',
+};
+
 const LifestylePage = () => {
   const [selectedLabel, setSelectedLabel] = useState<Tag>(TAGS[0]);
   const [isAutoRotate, setIsAutoRotate] = useState(true);
   const [isPaused, setIsPaused] = useState(false);
+  const selectedTagKey = useMemo(() => LABEL_TO_TAGKEY[selectedLabel], [selectedLabel]);
+  const { data: lifestyleResult } = useGetLifestyleDevice(selectedTagKey);
+  const devices = useMemo(() => {
+    const list = lifestyleResult?.devices ?? [];
+    return [...list].sort((a, b) => a.slot - b.slot);
+  }, [lifestyleResult]);
 
   const targetSrc = useMemo(() => TAG_IMAGE_MAP[selectedLabel], [selectedLabel]);
   const { currentSrc, nextSrc, isNextVisible } = useCrossfadeImage(targetSrc, {
     transitionMs: TRANSITION_MS,
   });
+
   const getNextTag = useCallback((prev: Tag) => nextInArray(TAGS, prev), []);
   const resumeTimerRef = useRef<number | null>(null);
   const resumeAtRef = useRef<number | null>(null);
@@ -50,25 +67,20 @@ const LifestylePage = () => {
     setSelectedLabel(label);
     setIsAutoRotate(false);
     resumeAtRef.current = now + USER_INTERACTION_PAUSE_MS;
-    if (resumeTimerRef.current) {
-      clearTimeout(resumeTimerRef.current);
-    }
-    const delay = USER_INTERACTION_PAUSE_MS;
+    if (resumeTimerRef.current) clearTimeout(resumeTimerRef.current);
     resumeTimerRef.current = window.setTimeout(() => {
-      if (Date.now() >= (resumeAtRef.current ?? 0)) {
-        setIsAutoRotate(true);
-      }
-    }, delay);
+      if (Date.now() >= (resumeAtRef.current ?? 0)) setIsAutoRotate(true);
+    }, USER_INTERACTION_PAUSE_MS);
   };
 
-useEffect(() => {
-  return () => {
-    if (resumeTimerRef.current) {
-      clearTimeout(resumeTimerRef.current);
-      resumeTimerRef.current = null;
-    }
-  };
-}, []);
+  useEffect(() => {
+    return () => {
+      if (resumeTimerRef.current) {
+        clearTimeout(resumeTimerRef.current);
+        resumeTimerRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <div className="min-h-[calc(100vh-80px)] flex items-center justify-center">
@@ -90,9 +102,9 @@ useEffect(() => {
             onMouseLeave={() => setIsPaused(false)}
           >
             <div className="flex absolute bottom-24 left-1/2 -translate-x-1/2 gap-20 z-10">
-              <DeviceSummaryCard />
-              <DeviceSummaryCard />
-              <DeviceSummaryCard />
+              <DeviceSummaryCard device={devices[0]} />
+              <DeviceSummaryCard device={devices[1]} />
+              <DeviceSummaryCard device={devices[2]} />
             </div>
             <img
               src={currentSrc}

--- a/src/pages/lifestyle/LifestylePage.tsx
+++ b/src/pages/lifestyle/LifestylePage.tsx
@@ -18,10 +18,12 @@ const LifestylePage = () => {
   const [selectedLabel, setSelectedLabel] = useState<LifestyleLabel>(LIFESTYLE_TAGS[0]);
   const [isAutoRotate, setIsAutoRotate] = useState(true);
   const [isPaused, setIsPaused] = useState(false);
+
   const selectedTagKey = useMemo<LifestyleTagKey>(
     () => LIFESTYLE_LABEL_TO_TAGKEY[selectedLabel],
     [selectedLabel]
   );
+
   const { data } = useGetLifestyleDevice(selectedTagKey);
   const isSuccess = data?.success === true;
   const lifestyleResult = isSuccess ? data?.result : null;
@@ -40,6 +42,7 @@ const LifestylePage = () => {
 
   const resumeTimerRef = useRef<number | null>(null);
   const resumeAtRef = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
 
   useAutoRotate<LifestyleLabel>({
     enabled: isAutoRotate && !isPaused,
@@ -48,20 +51,29 @@ const LifestylePage = () => {
     getNext: getNextTag,
   });
 
-  const handleClickTag = (label: LifestyleLabel) => {
+  const handleClickTag = useCallback((label: LifestyleLabel) => {
     const now = Date.now();
+    if (resumeTimerRef.current !== null) {
+      clearTimeout(resumeTimerRef.current);
+      resumeTimerRef.current = null;
+    }
     setSelectedLabel(label);
     setIsAutoRotate(false);
+
     resumeAtRef.current = now + USER_INTERACTION_PAUSE_MS;
-    if (resumeTimerRef.current) clearTimeout(resumeTimerRef.current);
+
     resumeTimerRef.current = window.setTimeout(() => {
-      if (Date.now() >= (resumeAtRef.current ?? 0)) setIsAutoRotate(true);
+      if (!isMountedRef.current) return;
+      if (Date.now() >= (resumeAtRef.current ?? 0)) {
+        setIsAutoRotate(true);
+      }
     }, USER_INTERACTION_PAUSE_MS);
-  };
+  }, []);
 
   useEffect(() => {
     return () => {
-      if (resumeTimerRef.current) {
+      isMountedRef.current = false;
+      if (resumeTimerRef.current !== null) {
         clearTimeout(resumeTimerRef.current);
         resumeTimerRef.current = null;
       }

--- a/src/types/lifestyle/lifestyle.ts
+++ b/src/types/lifestyle/lifestyle.ts
@@ -1,0 +1,25 @@
+import { type CommonResponse } from '@/types/common';
+
+export type LifestyleTagKey = 'Office' | 'Developer' | 'Game' | 'Study' | 'Video-editing' | 'Tour';
+export type LifestyleTagType = 'LIFESTYLE';
+
+export type LifestyleDevice = {
+  slot: number;
+  deviceId: number;
+  imageUrl: string; 
+  displayName: string;
+  releaseDate: string;
+  price: number;
+  currency: 'KRW';
+};
+
+export type LifestyleDeviceResult = {
+  tagKey: LifestyleTagKey;
+  tagLabel: string;
+  tagType: LifestyleTagType;
+  devices: LifestyleDevice[];
+};
+
+export type LifestyleDeviceResponse = CommonResponse<LifestyleDeviceResult>;
+export type LifestyleDeviceErrorResponse = CommonResponse<null>;
+


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #108 

## 🔍 구현한 내용

- 라이프스타일 페이지 API 연동했습니다.

  - `tagKey` 기준으로 대표 디바이스 3개를 조회하고, 하단 기기 요약 카드에 노출되도록 했습니다.
  - 디바이스 목록은 slot 기준으로 정렬해 사용합니다.

- 라이프스타일 관련 상수와 타입을 분리했습니다.

  - 라이프스타일 태그 목록과 이미지 매핑을 `constants/lifestyle.ts`로 이동했습니다.
  - Label ↔ TagKey 매핑 구조로 UI와 API 간 책임을 분리했습니다.

- DeviceSummaryCard에 API 응답 데이터를 연결했습니다.

  - 이미지, 기기명, 출시일, 가격 정보를 실제 응답 값으로 렌더링합니다.
  - 데이터가 없는 경우를 고려해 fallback 처리를 추가했습니다.



## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/554e6dc5-0a5c-45ed-be75-b1a2ecba9fdc



## 📢 리뷰어에게
- `tagKey = tour` 일 때 첫 번째 기기 사진이 제대로 안 보여 pm님께 이미지 url 수정 요청 드린 상황입니다. 연동 상의 이상은 없습니다.