### PR TITLE
design: 연동 과정에서 조금 변한 css 수정하였습니다. 검색 flow, 마이페이지 flow 입니다.

### DIFF
--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -93,8 +93,8 @@ const CombinationDeviceCard = ({
               className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 ${deviceCardWidth} flex items-center gap-12`}
             >
               <div className={`${deviceImageSize} bg-gray-200 flex-shrink-0`} />
-              <div className="flex flex-col gap-4">
-                <p className="font-body-3-sm text-black">{device.name}</p>
+              <div className="flex flex-col gap-4 min-w-0">
+                <p className="font-body-3-sm text-black truncate">{device.name}</p>
                 <p className="font-body-4-r text-gray-300">{device.brandName}</p>
                 <p className="font-body-3-r text-gray-300">{device.deviceType}</p>
               </div>

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -98,7 +98,7 @@ const CombinationDeviceCard = ({
         {/* 그라데이션 */}
         {showGradient && shouldShowGradient && !showAllDevices && (
           <div
-            className={`absolute right-0 bottom-0 ${deviceCardWidth} h-80 rounded-card pointer-events-none`}
+            className={`absolute right-0 bottom-0 ${deviceCardWidth} h-82 rounded-card pointer-events-none`}
             style={{
               background: 'linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%)',
             }}

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -12,6 +12,7 @@ type CombinationDeviceCardProps = {
   className?: string;
   expanded?: boolean;
   onExpand?: (expanded: boolean) => void;
+  index?: number;
 };
 
 const CombinationDeviceCard = ({
@@ -24,6 +25,7 @@ const CombinationDeviceCard = ({
   className = '',
   expanded,
   onExpand,
+  index,
 }: CombinationDeviceCardProps) => {
   const [internalExpanded, setInternalExpanded] = useState(false);
 
@@ -61,6 +63,11 @@ const CombinationDeviceCard = ({
       <div className="flex flex-col gap-24 pl-20 py-24">
         {/* 조합명 */}
         <div className="flex flex-col gap-8">
+          {/* 조합 번호 */}
+          {index !== undefined && (
+            <p className="font-body-3-r text-gray-400">조합 {index + 1}</p>
+          )}
+          {/* 조합명 + 별 */}
           <div className="flex items-center gap-8">
             <p className="font-body-1-sm text-black">{combination.comboName}</p>
             {combination.isPinned && <StarIcon className="w-22 h-22" />}

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -60,7 +60,7 @@ const CombinationDeviceCard = ({
   return (
     <div className={className}>
       {/* 조합 정보 */}
-      <div className="flex flex-col gap-24 pl-20 py-24">
+      <div className="flex flex-col gap-24 pl-20 py-24 flex-shrink-0">
         {/* 조합명 */}
         <div className="flex flex-col gap-8">
           {/* 조합 번호 */}

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -54,8 +54,8 @@ const CombinationDeviceCard = ({
   };
 
   const gridColsClass = columns === 4 ? 'grid-cols-4' : 'grid-cols-3';
-  const deviceCardWidth = columns === 4 ? 'w-244' : 'w-244';
-  const deviceImageSize = columns === 4 ? 'w-64 h-64' : 'w-64 h-64';
+  const deviceCardWidth = 'w-244 h-87';
+  const deviceImageSize = 'w-63 h-63';
 
   return (
     <div className={className}>

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -70,7 +70,7 @@ const CombinationDeviceCard = ({
           {/* 조합명 + 별 */}
           <div className="flex items-center gap-8">
             <p className="font-body-1-sm text-black">{combination.comboName}</p>
-            {combination.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+            {combination.isPinned && <StarIcon className="w-22 h-22 -mt-3" />}
           </div>
         </div>
         {/* Tags */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -548,7 +548,7 @@ const DeviceSearchPage = () => {
 
                 {/* Card */}
                 <div
-                  className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] mb-50 overflow-y-auto scrollbar-minimal"
+                  className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] mb-50 flex flex-col overflow-y-auto scrollbar-minimal"
                   style={{
                     width: '907px',
                     height: '670px',
@@ -573,7 +573,7 @@ const DeviceSearchPage = () => {
                   {combinationDevices.length > 9 && !showAllDevices && (
                     <button
                       onClick={() => setShowAllDevices(true)}
-                      className="mt-16 px-56 pl-68 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80"
+                      className="mt-16 px-56 pl-68 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80 w-fit"
                     >
                       기기 전체보기
                     </button>
@@ -581,14 +581,14 @@ const DeviceSearchPage = () => {
                   {combinationDevices.length > 9 && showAllDevices && (
                     <button
                       onClick={() => setShowAllDevices(false)}
-                      className="mt-16 px-56 pl-68 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80"
+                      className="mt-16 px-56 pl-68 font-body-2-r text-gray-500 underline cursor-pointer hover:opacity-80 w-fit"
                     >
                       간략히 보기
                     </button>
                   )}
 
-                  {/* 버튼 컨테이너 - 토글 버튼으로부터 72px 간격 유지 */}
-                  <div className="px-40 pb-40 pt-72">
+                  {/* 버튼 컨테이너 - 토글 버튼으로부터 72px 간격 유지하며 하단 고정 */}
+                  <div className="px-40 pb-40 pt-72 mt-auto">
                     <div className="flex justify-end">
                       <PrimaryButton
                         text={isAlreadyInSelectedCombination ? '이미 담은 상품입니다.' : `${selectedCombination.comboName}에 담기`}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -625,7 +625,7 @@ const DeviceSearchPage = () => {
                     </button>
                   )}
 
-                  {/* 버튼 컨테이너 - 토글 버튼으로부터 72px 간격 유지하며 하단 고정 */}
+                  {/* 버튼 컨테이너 - 토글 버튼으로부터 간격 유지하며 하단 고정 */}
                   <div className="px-40 pb-40 pt-30 mt-auto">
                     <div className="flex justify-end">
                       <PrimaryButton

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -565,7 +565,7 @@ const DeviceSearchPage = () => {
                     onExpand={(value) => setShowAllDevices(value)}
                     showExpandButton={false}
                     showGradient={true}
-                    className="px-56 pt-40 pb-0"
+                    className="px-56 pt-40 pb-0 flex-shrink-0"
                     index={combos.findIndex(c => c.comboId === selectedCombinationId)}
                   />
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -566,6 +566,7 @@ const DeviceSearchPage = () => {
                     showExpandButton={false}
                     showGradient={true}
                     className="px-56 pt-40 pb-0"
+                    index={combos.findIndex(c => c.comboId === selectedCombinationId)}
                   />
 
                   {/* 토글 버튼 - CombinationDeviceCard 외부에 배치 */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -589,7 +589,7 @@ const DeviceSearchPage = () => {
                   className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] mb-50 flex flex-col overflow-y-auto scrollbar-minimal"
                   style={{
                     width: '907px',
-                    height: '670px',
+                    height:'670px',
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -626,7 +626,7 @@ const DeviceSearchPage = () => {
                   )}
 
                   {/* 버튼 컨테이너 - 토글 버튼으로부터 72px 간격 유지하며 하단 고정 */}
-                  <div className="px-40 pb-40 pt-72 mt-auto">
+                  <div className="px-40 pb-40 pt-30 mt-auto">
                     <div className="flex justify-end">
                       <PrimaryButton
                         text={isAlreadyInSelectedCombination ? '이미 담은 상품입니다.' : `${selectedCombination.comboName}에 담기`}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -484,7 +484,7 @@ const DeviceSearchPage = () => {
                   onClick={(e) => e.stopPropagation()}
                 >
                   {/* Combination List */}
-                  <div className="flex flex-col mx-20 overflow-y-auto max-h-630 scrollbar-minimal">
+                  <div className="flex flex-col ml-20 overflow-y-auto h-full scrollbar-minimal">
                     {combos.map((combo, index) => (
                       <button
                         key={combo.comboId}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -371,7 +371,7 @@ const DeviceSearchPage = () => {
 
                 {/* Card */}
                 <div
-                  className="bg-white rounded-card px-56 py-40"
+                  className="bg-white rounded-card px-56 py-40 overflow-y-auto scrollbar-minimal"
                   style={{
                     width: '907px',
                     height: '670px',

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -537,7 +537,7 @@ const DeviceSearchPage = () => {
                             {/* 조합명 + 대표조합 star */}
                             <div className="flex items-center gap-8">
                               <p className="font-body-1-sm text-black">{combo.comboName}</p>
-                              {combo.isPinned && <StarIcon className="w-22 h-22 -mt-2" />}
+                              {combo.isPinned && <StarIcon className="w-22 h-22 -mt-3" />}
                             </div>
                           </div>
                           {/* 기기 수 + 총 가격 */}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -1034,7 +1034,7 @@ const MyPage = () => {
                                     {combination.isPinned ? (
                                       <StarIcon
                                         onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                        className={`!w-22 !h-22 -mt-2 cursor-pointer transition-opacity ${
+                                        className={`!w-22 !h-22 -mt-3 cursor-pointer transition-opacity ${
                                           hoveredStarComboId === combination.comboId ? 'opacity-80' : ''
                                         }`}
                                         onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
@@ -1045,14 +1045,14 @@ const MyPage = () => {
                                         {hoveredStarComboId === combination.comboId ? (
                                           <StarHoverIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                            className="!w-22 !h-22 -mt-2 cursor-pointer"
+                                            className="!w-22 !h-22 -mt-3 cursor-pointer"
                                             onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
                                         ) : (
                                           <StarXIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                            className="!w-22 !h-22 -mt-2 cursor-pointer"
+                                            className="!w-22 !h-22 -mt-3 cursor-pointer"
                                             onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
@@ -1127,7 +1127,7 @@ const MyPage = () => {
                                   {combination.isPinned ? (
                                     <StarIcon
                                       onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                      className={`!w-22 !h-22 -mt-2 cursor-pointer transition-opacity ${
+                                      className={`!w-22 !h-22 -mt-3 cursor-pointer transition-opacity ${
                                         hoveredStarComboId === combination.comboId ? 'opacity-80' : ''
                                       }`}
                                       onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
@@ -1138,14 +1138,14 @@ const MyPage = () => {
                                       {hoveredStarComboId === combination.comboId ? (
                                         <StarHoverIcon
                                           onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                          className="!w-22 !h-22 -mt-2 cursor-pointer"
+                                          className="!w-22 !h-22 -mt-3 cursor-pointer"
                                           onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
                                           onMouseLeave={() => setHoveredStarComboId(null)}
                                         />
                                       ) : (
                                         <StarXIcon
                                           onClick={(e) => handleTogglePin(e, combination.comboId)}
-                                          className="!w-22 !h-22 -mt-2 cursor-pointer"
+                                          className="!w-22 !h-22 -mt-3 cursor-pointer"
                                           onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
                                           onMouseLeave={() => setHoveredStarComboId(null)}
                                         />


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #124 

## 🔍 구현한 내용

- 기기 검색 flow 중, 조합 리스트 -> 스크롤 우측과 하단 마진 수정하였습니다.
- 조합 상세보기(기기 전체 보는 창) 그라데이션 수정하였습니다.
- 조합 상세보기에서 (ex.조합1) 이름 표시하도록 수정하였습니다.
- 기기 검색 페이지 product 기기명이 2줄을 넘어갈 경우 상세보기에서 스크롤 구현하도록 하였습니다. 
  (이건 나중에 API 연결하고 확인해야합니다.)
- 조합 상세보기 product 크기 수정하였습니다.
- 조합 상세보기, 기기가 없거나 적은 경우에도 버튼 하단에 뜨도록 고정하였습니다.
- 조합 상세보기, 제품 이름 2줄이상일 경우 ...으로 표기하였습니다.
- 기기 전체보기, 간략히 보기 동작 부드럽게 진행되도록 수정하였습니다.
- 별 아이콘 -mt-3으로 1 위로 올렸습니다.
- 조합 상세보기, 기기 전체보기가 있을 경우 버튼 위치 수정하여 스크롤 뜨지 않도록 수정하였습니다.


## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
