### PR TITLE
feat: 마이페이지 유저 프로필 조회 API 연동

### DIFF
--- a/src/apis/mypage/getUserProfile.ts
+++ b/src/apis/mypage/getUserProfile.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/apis/axios/axios';
 import type { UserProfileResponse, UserProfileResult } from '@/types/mypage/user';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
 import { hasAuthTokens } from '@/utils/auth/authStorage';
 
@@ -13,13 +13,11 @@ export const getUserProfile = async (): Promise<UserProfileResult | undefined> =
 // 유저 정보 조회 Query
 export const useGetUserProfile = () => {
   const hasTokens = hasAuthTokens();
-  const queryClient = useQueryClient();
+
   return useQuery<UserProfileResult | undefined>({
     queryKey: [queryKey.USER_PROFILE],
     queryFn: getUserProfile,
     enabled: hasTokens, // 토큰이 있을 때만 조회
     staleTime: 1000 * 60 * 10,
-    placeholderData: () =>
-      queryClient.getQueryData<UserProfileResult | undefined>([queryKey.USER_PROFILE]),
   });
 };

--- a/src/apis/mypage/getUserProfile.ts
+++ b/src/apis/mypage/getUserProfile.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/apis/axios/axios';
 import type { UserProfileResponse, UserProfileResult } from '@/types/mypage/user';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
 import { hasAuthTokens } from '@/utils/auth/authStorage';
 
@@ -13,9 +13,13 @@ export const getUserProfile = async (): Promise<UserProfileResult | undefined> =
 // 유저 정보 조회 Query
 export const useGetUserProfile = () => {
   const hasTokens = hasAuthTokens();
+  const queryClient = useQueryClient();
   return useQuery<UserProfileResult | undefined>({
     queryKey: [queryKey.USER_PROFILE],
     queryFn: getUserProfile,
     enabled: hasTokens, // 토큰이 있을 때만 조회
+    staleTime: 1000 * 60 * 10,
+    placeholderData: () =>
+      queryClient.getQueryData<UserProfileResult | undefined>([queryKey.USER_PROFILE]),
   });
 };

--- a/src/components/Home/GNB.tsx
+++ b/src/components/Home/GNB.tsx
@@ -8,7 +8,7 @@ import { useLogout } from '@/hooks/useLogout';
 import { useAuth } from '@/hooks/useAuth';
 import { ROUTES } from '@/constants/routes';
 
-const NAV_TEXT_CLASS = 'font-body-1-sm text-black hover:text-blue-500 active:text-blue-600';
+const NAV_TEXT_CLASS = 'font-body-1-sm text-black hover:text-blue-500 active:text-blue-600 cursor-pointer';
 const USER_BLUE_500_CLASS = 'absolute inset-0 opacity-0 group-hover:opacity-100';
 
 interface GNBProps {

--- a/src/components/Lifestyle/RoundedLifestyleTag.tsx
+++ b/src/components/Lifestyle/RoundedLifestyleTag.tsx
@@ -34,7 +34,7 @@ const RoundedLifestyleTag = (props: RoundedLifestyleTagProps) => {
         ${cursorClass}
       `}
     >
-      # {props.label}
+      {props.label}
     </div>
   );
 };

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -529,7 +529,11 @@ const MyPage = () => {
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
                 <div className="flex flex-wrap gap-12 content-start">
-                  <RoundedLifestyleTag label="Office" />
+                  <RoundedLifestyleTag
+                    label={
+                      (userProfile?.lifestyleList?.[0] ?? '').replace(/^#\s*/, '')
+                    }
+                  />
                 </div>
               </div>
             </div>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -29,6 +29,9 @@ import { useDeleteCombo } from '@/apis/combo/deleteCombo';
 import { usePostComboPin } from '@/apis/combo/postComboPin';
 import { useDeleteComboDevice } from '@/apis/combo/deleteComboDevice';
 import type { ComboListItem } from '@/types/combo/combo';
+import { useQueryClient } from '@tanstack/react-query';
+import type { UserProfileResult } from '@/types/mypage/user';
+import { queryKey } from '@/constants/queryKey';
 
 // 조합 평가 Mock 데이터
 const MOCK_EVALUATION = {
@@ -98,6 +101,8 @@ const MyPage = () => {
   const { mutate: deleteCombo, isPending: isDeleting } = useDeleteCombo();
   const { mutate: togglePin } = usePostComboPin();
   const { mutate: deleteDevice, isPending: isDeletingDevice } = useDeleteComboDevice();
+  const queryClient = useQueryClient();
+  const userProfile = queryClient.getQueryData<UserProfileResult>([queryKey.USER_PROFILE]);
 
   // 정렬된 조합 목록
   const sortedCombos = useMemo(() => {
@@ -490,7 +495,8 @@ const MyPage = () => {
                   href="https://lovely-potassium-7f2.notion.site/2f0c82f125c980fa8fa0d2ef430bbe79?pvs=74"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="w-42 h-42 flex items-center justify-center cursor-pointer hover:opacity-80">
+                  className="w-42 h-42 flex items-center justify-center cursor-pointer hover:opacity-80"
+                >
                   <SupportIcon className="w-42 h-42 text-black" />
                 </a>
                 <button
@@ -505,18 +511,20 @@ const MyPage = () => {
             {/* 프로필 카드 */}
             <div className="mt-60 h-100 rounded-card border border-blue-300 flex items-center justify-center gap-30">
               <Logo className="w-48 h-48 flex-shrink-0" />
-              <p className="font-heading-2 text-black">000 님</p>
+              <p className="font-heading-2 text-black">{userProfile?.username ?? '000'} 님</p>
             </div>
 
             {/* 사용자 정보 */}
             <div className="mt-44 flex flex-col gap-16">
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">가입일</p>
-                <p className="font-body-2-r text-black">2023.12.22</p>
+                <p className="font-body-2-r text-black">
+                  {userProfile?.createdAt ? formatDate(userProfile.createdAt) : '-'}
+                </p>
               </div>
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">이메일</p>
-                <p className="font-body-2-r text-black truncate">example@devicelife.com</p>
+                <p className="font-body-2-r text-black truncate">{userProfile?.email ?? '-'}</p>
               </div>
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
@@ -528,10 +536,7 @@ const MyPage = () => {
           </div>
 
           {/* 최근에 본 기기 플로팅 섹션 */}
-          <RecentlyViewedFloating
-            userName="000"
-            sidebarContentRef={sidebarContentRef}
-          />
+          <RecentlyViewedFloating userName="000" sidebarContentRef={sidebarContentRef} />
         </aside>
 
         {/* 우측 메인 콘텐츠 */}
@@ -619,7 +624,12 @@ const MyPage = () => {
 
                   {/* 조합 카드 */}
                   <div
-                    onClick={() => !isDetailView && editingComboId !== combination.comboId && hasDevices && handleDetailView(combination.comboId)}
+                    onClick={() =>
+                      !isDetailView &&
+                      editingComboId !== combination.comboId &&
+                      hasDevices &&
+                      handleDetailView(combination.comboId)
+                    }
                     className={`rounded-card relative ${
                       isDetailView
                         ? 'bg-blue-100'
@@ -645,7 +655,9 @@ const MyPage = () => {
                                 setShowSaveModal(true);
                               }
                             }}
-                            disabled={!isComboNameValid || editingCombinationName.trim().length === 0}
+                            disabled={
+                              !isComboNameValid || editingCombinationName.trim().length === 0
+                            }
                             className="w-150"
                           />
                         ) : (
@@ -653,7 +665,9 @@ const MyPage = () => {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              setOpenMenuIndex(openMenuIndex === combination.comboId ? null : combination.comboId);
+                              setOpenMenuIndex(
+                                openMenuIndex === combination.comboId ? null : combination.comboId
+                              );
                             }}
                             className="cursor-pointer hover:opacity-80"
                           >
@@ -762,14 +776,18 @@ const MyPage = () => {
                                     <StarHoverIcon
                                       onClick={(e) => handleTogglePin(e, combination.comboId)}
                                       className="!w-22 !h-22 -mt-2 cursor-pointer"
-                                      onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                      onMouseEnter={() =>
+                                        setHoveredStarComboId(combination.comboId)
+                                      }
                                       onMouseLeave={() => setHoveredStarComboId(null)}
                                     />
                                   ) : (
                                     <StarXIcon
                                       onClick={(e) => handleTogglePin(e, combination.comboId)}
                                       className="!w-22 !h-22 -mt-2 cursor-pointer"
-                                      onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                      onMouseEnter={() =>
+                                        setHoveredStarComboId(combination.comboId)
+                                      }
                                       onMouseLeave={() => setHoveredStarComboId(null)}
                                     />
                                   )}
@@ -817,7 +835,9 @@ const MyPage = () => {
                             {devices.map((device) => (
                               <div
                                 key={device.deviceId}
-                                onClick={() => window.open(`/devices?productId=${device.deviceId}`, '_blank')}
+                                onClick={() =>
+                                  window.open(`/devices?productId=${device.deviceId}`, '_blank')
+                                }
                                 className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow ${selectedDevices.includes(device.deviceId) ? 'border-blue-600' : 'border-transparent'}`}
                               >
                                 <div className="w-64 h-64 bg-gray-200 flex-shrink-0 relative group/image">
@@ -848,8 +868,12 @@ const MyPage = () => {
                                       )}
                                     </button>
                                   </div>
-                                  <p className="font-body-4-r text-gray-300">{device.brandName || '-'}</p>
-                                  <p className="font-body-3-r text-gray-300">{device.deviceType || '-'}</p>
+                                  <p className="font-body-4-r text-gray-300">
+                                    {device.brandName || '-'}
+                                  </p>
+                                  <p className="font-body-3-r text-gray-300">
+                                    {device.deviceType || '-'}
+                                  </p>
                                 </div>
                               </div>
                             ))}
@@ -873,7 +897,9 @@ const MyPage = () => {
                             <div className="flex items-center gap-4">
                               <p className="font-body-1-sm text-blue-600">₩</p>
                               <p className="font-body-1-sm text-blue-600">
-                                {(comboDetail?.totalPrice ?? combination.totalPrice).toLocaleString()}
+                                {(
+                                  comboDetail?.totalPrice ?? combination.totalPrice
+                                ).toLocaleString()}
                               </p>
                             </div>
                           </div>
@@ -885,7 +911,9 @@ const MyPage = () => {
                         {/* 조합 평가 정보 */}
                         <div className="px-56 py-56">
                           <div className="flex items-center justify-end gap-16 mb-32">
-                            <p className="font-body-2-r text-gray-400 underline">조합평가 전문보기</p>
+                            <p className="font-body-2-r text-gray-400 underline">
+                              조합평가 전문보기
+                            </p>
                           </div>
 
                           <div className="flex flex-col gap-20">
@@ -983,7 +1011,9 @@ const MyPage = () => {
                                       }}
                                       maxLength={20}
                                       className={`h-52 px-12 rounded-button font-body-1-sm text-gray-300 focus:outline-none ${
-                                        comboNameError ? 'border-2 border-warning' : 'border border-blue-600'
+                                        comboNameError
+                                          ? 'border-2 border-warning'
+                                          : 'border border-blue-600'
                                       }`}
                                       autoFocus
                                     />
@@ -991,9 +1021,13 @@ const MyPage = () => {
                                       <StarIcon
                                         onClick={(e) => handleTogglePin(e, combination.comboId)}
                                         className={`!w-22 !h-22 -mt-2 cursor-pointer transition-opacity ${
-                                          hoveredStarComboId === combination.comboId ? 'opacity-80' : ''
+                                          hoveredStarComboId === combination.comboId
+                                            ? 'opacity-80'
+                                            : ''
                                         }`}
-                                        onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                        onMouseEnter={() =>
+                                          setHoveredStarComboId(combination.comboId)
+                                        }
                                         onMouseLeave={() => setHoveredStarComboId(null)}
                                       />
                                     ) : (
@@ -1002,14 +1036,18 @@ const MyPage = () => {
                                           <StarHoverIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
                                             className="!w-22 !h-22 -mt-2 cursor-pointer"
-                                            onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                            onMouseEnter={() =>
+                                              setHoveredStarComboId(combination.comboId)
+                                            }
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
                                         ) : (
                                           <StarXIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
                                             className="!w-22 !h-22 -mt-2 cursor-pointer"
-                                            onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                            onMouseEnter={() =>
+                                              setHoveredStarComboId(combination.comboId)
+                                            }
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
                                         )}
@@ -1017,7 +1055,9 @@ const MyPage = () => {
                                     )}
                                   </div>
                                   {comboNameError && (
-                                    <p className="pl-12 font-body-4-r text-warning">{comboNameError}</p>
+                                    <p className="pl-12 font-body-4-r text-warning">
+                                      {comboNameError}
+                                    </p>
                                   )}
                                 </div>
                               ) : (
@@ -1030,14 +1070,20 @@ const MyPage = () => {
                                     </p>
                                   </div>
                                   <div className="flex items-center gap-8">
-                                    <p className="font-body-1-sm text-black">{combination.comboName}</p>
+                                    <p className="font-body-1-sm text-black">
+                                      {combination.comboName}
+                                    </p>
                                     {combination.isPinned ? (
                                       <StarIcon
                                         onClick={(e) => handleTogglePin(e, combination.comboId)}
                                         className={`!w-22 !h-22 -mt-3 cursor-pointer transition-opacity ${
-                                          hoveredStarComboId === combination.comboId ? 'opacity-80' : ''
+                                          hoveredStarComboId === combination.comboId
+                                            ? 'opacity-80'
+                                            : ''
                                         }`}
-                                        onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                        onMouseEnter={() =>
+                                          setHoveredStarComboId(combination.comboId)
+                                        }
                                         onMouseLeave={() => setHoveredStarComboId(null)}
                                       />
                                     ) : (
@@ -1046,14 +1092,18 @@ const MyPage = () => {
                                           <StarHoverIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
                                             className="!w-22 !h-22 -mt-3 cursor-pointer"
-                                            onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                            onMouseEnter={() =>
+                                              setHoveredStarComboId(combination.comboId)
+                                            }
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
                                         ) : (
                                           <StarXIcon
                                             onClick={(e) => handleTogglePin(e, combination.comboId)}
                                             className="!w-22 !h-22 -mt-3 cursor-pointer"
-                                            onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                            onMouseEnter={() =>
+                                              setHoveredStarComboId(combination.comboId)
+                                            }
                                             onMouseLeave={() => setHoveredStarComboId(null)}
                                           />
                                         )}
@@ -1070,7 +1120,8 @@ const MyPage = () => {
                               {(() => {
                                 // 그라데이션 임계값 설정
                                 const gradientThreshold = columns === 4 ? 9 : 7;
-                                const shouldShowGradient = combination.devices.length >= gradientThreshold;
+                                const shouldShowGradient =
+                                  combination.devices.length >= gradientThreshold;
                                 const maxDisplay = columns === 4 ? 8 : 6;
                                 const displayedDevices = shouldShowGradient
                                   ? combination.devices.slice(0, maxDisplay)
@@ -1078,7 +1129,9 @@ const MyPage = () => {
 
                                 return (
                                   <>
-                                    <div className={`grid ${columns === 4 ? 'grid-cols-4' : 'grid-cols-3'} gap-x-28 gap-y-12`}>
+                                    <div
+                                      className={`grid ${columns === 4 ? 'grid-cols-4' : 'grid-cols-3'} gap-x-28 gap-y-12`}
+                                    >
                                       {displayedDevices.map((device) => (
                                         <div
                                           key={device.deviceId}
@@ -1089,8 +1142,12 @@ const MyPage = () => {
                                             <p className="font-body-3-sm text-black truncate w-120">
                                               {device.name}
                                             </p>
-                                            <p className="font-body-4-r text-gray-300">{device.brandName}</p>
-                                            <p className="font-body-3-r text-gray-300">{device.deviceType}</p>
+                                            <p className="font-body-4-r text-gray-300">
+                                              {device.brandName}
+                                            </p>
+                                            <p className="font-body-3-r text-gray-300">
+                                              {device.deviceType}
+                                            </p>
                                           </div>
                                         </div>
                                       ))}
@@ -1101,7 +1158,8 @@ const MyPage = () => {
                                       <div
                                         className="absolute right-0 bottom-0 w-244 h-80 rounded-card pointer-events-none"
                                         style={{
-                                          background: 'linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%)',
+                                          background:
+                                            'linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 70%)',
                                         }}
                                       />
                                     )}
@@ -1123,14 +1181,20 @@ const MyPage = () => {
                                   </p>
                                 </div>
                                 <div className="flex items-center gap-8">
-                                  <p className="font-body-1-sm text-black">{combination.comboName}</p>
+                                  <p className="font-body-1-sm text-black">
+                                    {combination.comboName}
+                                  </p>
                                   {combination.isPinned ? (
                                     <StarIcon
                                       onClick={(e) => handleTogglePin(e, combination.comboId)}
                                       className={`!w-22 !h-22 -mt-3 cursor-pointer transition-opacity ${
-                                        hoveredStarComboId === combination.comboId ? 'opacity-80' : ''
+                                        hoveredStarComboId === combination.comboId
+                                          ? 'opacity-80'
+                                          : ''
                                       }`}
-                                      onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                      onMouseEnter={() =>
+                                        setHoveredStarComboId(combination.comboId)
+                                      }
                                       onMouseLeave={() => setHoveredStarComboId(null)}
                                     />
                                   ) : (
@@ -1139,14 +1203,18 @@ const MyPage = () => {
                                         <StarHoverIcon
                                           onClick={(e) => handleTogglePin(e, combination.comboId)}
                                           className="!w-22 !h-22 -mt-3 cursor-pointer"
-                                          onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                          onMouseEnter={() =>
+                                            setHoveredStarComboId(combination.comboId)
+                                          }
                                           onMouseLeave={() => setHoveredStarComboId(null)}
                                         />
                                       ) : (
                                         <StarXIcon
                                           onClick={(e) => handleTogglePin(e, combination.comboId)}
                                           className="!w-22 !h-22 -mt-3 cursor-pointer"
-                                          onMouseEnter={() => setHoveredStarComboId(combination.comboId)}
+                                          onMouseEnter={() =>
+                                            setHoveredStarComboId(combination.comboId)
+                                          }
                                           onMouseLeave={() => setHoveredStarComboId(null)}
                                         />
                                       )}
@@ -1213,9 +1281,7 @@ const MyPage = () => {
               <RemoveIcon className="w-58 h-58" />
 
               {/* 텍스트 */}
-              <p className="font-body-2-r text-black mt-36">
-                선택한 기기들을 삭제하시겠습니까?
-              </p>
+              <p className="font-body-2-r text-black mt-36">선택한 기기들을 삭제하시겠습니까?</p>
 
               {/* 버튼 그룹 */}
               <div className="flex gap-20 mt-60">
@@ -1243,70 +1309,70 @@ const MyPage = () => {
       )}
 
       {/* 조합 삭제 확인 모달 */}
-      {showCombinationDeleteModal && deleteTargetComboId !== null && (() => {
-        const targetCombo = sortedCombos.find(c => c.comboId === deleteTargetComboId);
-        if (!targetCombo) return null;
-        return (
-          <>
-            {/* 배경 오버레이 */}
-            <div
-              className="fixed inset-0 bg-black/50 z-60"
-              onClick={() => {
-                setShowCombinationDeleteModal(false);
-                setDeleteTargetComboId(null);
-              }}
-            />
-            {/* 모달 */}
-            <div className="fixed inset-0 flex items-center justify-center z-70 pointer-events-none">
+      {showCombinationDeleteModal &&
+        deleteTargetComboId !== null &&
+        (() => {
+          const targetCombo = sortedCombos.find((c) => c.comboId === deleteTargetComboId);
+          if (!targetCombo) return null;
+          return (
+            <>
+              {/* 배경 오버레이 */}
               <div
-                className="bg-white rounded-card w-460 px-36 py-44 flex flex-col items-center pointer-events-auto"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {/* 아이콘 */}
-                <RemoveIcon className="w-58 h-58" />
+                className="fixed inset-0 bg-black/50 z-60"
+                onClick={() => {
+                  setShowCombinationDeleteModal(false);
+                  setDeleteTargetComboId(null);
+                }}
+              />
+              {/* 모달 */}
+              <div className="fixed inset-0 flex items-center justify-center z-70 pointer-events-none">
+                <div
+                  className="bg-white rounded-card w-460 px-36 py-44 flex flex-col items-center pointer-events-auto"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {/* 아이콘 */}
+                  <RemoveIcon className="w-58 h-58" />
 
-                {/* 텍스트 */}
-                <p className="font-body-2-r text-black mt-36">
-                  '<span className="font-body-2-sm">{targetCombo.comboName}</span>'을 삭제하시겠습니까?
-                </p>
+                  {/* 텍스트 */}
+                  <p className="font-body-2-r text-black mt-36">
+                    '<span className="font-body-2-sm">{targetCombo.comboName}</span>'을
+                    삭제하시겠습니까?
+                  </p>
 
-                {/* 버튼 그룹 */}
-                <div className="flex gap-20 mt-60">
-                  <button
-                    onClick={handleDeleteCombination}
-                    disabled={isDeleting}
-                    className={`w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center transition-colors ${
-                      isDeleting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
-                    }`}
-                  >
-                    <span className="font-body-2-sm text-white">
-                      {isDeleting ? '삭제 중...' : '삭제'}
-                    </span>
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowCombinationDeleteModal(false);
-                      setDeleteTargetComboId(null);
-                    }}
-                    className="w-168 h-52 bg-gray-100 hover:bg-gray-200 rounded-button flex items-center justify-center cursor-pointer transition-colors"
-                  >
-                    <span className="font-body-2-sm text-black">취소</span>
-                  </button>
+                  {/* 버튼 그룹 */}
+                  <div className="flex gap-20 mt-60">
+                    <button
+                      onClick={handleDeleteCombination}
+                      disabled={isDeleting}
+                      className={`w-168 h-52 bg-red-500 hover:bg-red-400 rounded-button flex items-center justify-center transition-colors ${
+                        isDeleting ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
+                      }`}
+                    >
+                      <span className="font-body-2-sm text-white">
+                        {isDeleting ? '삭제 중...' : '삭제'}
+                      </span>
+                    </button>
+                    <button
+                      onClick={() => {
+                        setShowCombinationDeleteModal(false);
+                        setDeleteTargetComboId(null);
+                      }}
+                      className="w-168 h-52 bg-gray-100 hover:bg-gray-200 rounded-button flex items-center justify-center cursor-pointer transition-colors"
+                    >
+                      <span className="font-body-2-sm text-black">취소</span>
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          </>
-        );
-      })()}
+            </>
+          );
+        })()}
 
       {/* 조합명 저장 확인 모달 */}
       {showSaveModal && (
         <>
           {/* 배경 오버레이 */}
-          <div
-            className="fixed inset-0 bg-black/50 z-60"
-            onClick={() => setShowSaveModal(false)}
-          />
+          <div className="fixed inset-0 bg-black/50 z-60" onClick={() => setShowSaveModal(false)} />
           {/* 모달 */}
           <div className="fixed inset-0 flex items-center justify-center z-70 pointer-events-none">
             <div
@@ -1317,9 +1383,7 @@ const MyPage = () => {
               <SaveIcon className="w-58 h-58 text-blue-600" />
 
               {/* 텍스트 */}
-              <p className="font-body-2-r text-black mt-36">
-                조합명을 저장하시겠습니까?
-              </p>
+              <p className="font-body-2-r text-black mt-36">조합명을 저장하시겠습니까?</p>
 
               {/* 버튼 그룹 */}
               <div className="flex gap-20 mt-60">
@@ -1349,16 +1413,18 @@ const MyPage = () => {
       {showDeleteSuccessModal && (
         <>
           {/* 배경 오버레이 */}
-          <div className={`fixed inset-0 bg-black/10 z-60 transition-opacity duration-200 ${isDeleteFadingOut ? 'opacity-0' : 'opacity-100'}`} />
+          <div
+            className={`fixed inset-0 bg-black/10 z-60 transition-opacity duration-200 ${isDeleteFadingOut ? 'opacity-0' : 'opacity-100'}`}
+          />
           {/* 팝업 */}
-          <div className={`fixed inset-0 flex items-center justify-center z-70 pointer-events-none transition-opacity duration-200 ${isDeleteFadingOut ? 'opacity-0' : 'opacity-100'}`}>
+          <div
+            className={`fixed inset-0 flex items-center justify-center z-70 pointer-events-none transition-opacity duration-200 ${isDeleteFadingOut ? 'opacity-0' : 'opacity-100'}`}
+          >
             <div className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] w-300 h-300 flex flex-col items-center justify-center pointer-events-auto animate-fade-in">
               {/* 아이콘 */}
               <RemoveIcon className="w-100 h-100 text-warning" />
               {/* 텍스트 */}
-              <p className="font-heading-3 text-black mt-42">
-                삭제 완료
-              </p>
+              <p className="font-heading-3 text-black mt-42">삭제 완료</p>
             </div>
           </div>
         </>
@@ -1368,16 +1434,18 @@ const MyPage = () => {
       {showSaveSuccessModal && (
         <>
           {/* 배경 오버레이 */}
-          <div className={`fixed inset-0 bg-black/10 z-60 transition-opacity duration-200 ${isSaveFadingOut ? 'opacity-0' : 'opacity-100'}`} />
+          <div
+            className={`fixed inset-0 bg-black/10 z-60 transition-opacity duration-200 ${isSaveFadingOut ? 'opacity-0' : 'opacity-100'}`}
+          />
           {/* 팝업 */}
-          <div className={`fixed inset-0 flex items-center justify-center z-70 pointer-events-none transition-opacity duration-200 ${isSaveFadingOut ? 'opacity-0' : 'opacity-100'}`}>
+          <div
+            className={`fixed inset-0 flex items-center justify-center z-70 pointer-events-none transition-opacity duration-200 ${isSaveFadingOut ? 'opacity-0' : 'opacity-100'}`}
+          >
             <div className="bg-white rounded-card shadow-[0_0_10px_rgba(0,0,0,0.25)] w-300 h-300 flex flex-col items-center justify-center pointer-events-auto animate-fade-in">
               {/* 파란 체크 아이콘 */}
               <SaveIcon className="w-100 h-100 text-blue-600" />
               {/* 텍스트 */}
-              <p className="font-heading-3 text-blue-600 mt-42">
-                저장 완료!
-              </p>
+              <p className="font-heading-3 text-blue-600 mt-42">저장 완료!</p>
             </div>
           </div>
         </>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -536,7 +536,10 @@ const MyPage = () => {
           </div>
 
           {/* 최근에 본 기기 플로팅 섹션 */}
-          <RecentlyViewedFloating userName="000" sidebarContentRef={sidebarContentRef} />
+          <RecentlyViewedFloating
+            userName={userProfile?.username ?? '000'}
+            sidebarContentRef={sidebarContentRef}
+          />
         </aside>
 
         {/* 우측 메인 콘텐츠 */}

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -29,9 +29,7 @@ import { useDeleteCombo } from '@/apis/combo/deleteCombo';
 import { usePostComboPin } from '@/apis/combo/postComboPin';
 import { useDeleteComboDevice } from '@/apis/combo/deleteComboDevice';
 import type { ComboListItem } from '@/types/combo/combo';
-import { useQueryClient } from '@tanstack/react-query';
-import type { UserProfileResult } from '@/types/mypage/user';
-import { queryKey } from '@/constants/queryKey';
+import { useAuth } from '@/hooks/useAuth';
 
 // 조합 평가 Mock 데이터
 const MOCK_EVALUATION = {
@@ -101,8 +99,7 @@ const MyPage = () => {
   const { mutate: deleteCombo, isPending: isDeleting } = useDeleteCombo();
   const { mutate: togglePin } = usePostComboPin();
   const { mutate: deleteDevice, isPending: isDeletingDevice } = useDeleteComboDevice();
-  const queryClient = useQueryClient();
-  const userProfile = queryClient.getQueryData<UserProfileResult>([queryKey.USER_PROFILE]);
+  const { user: userProfile, isAuthLoading } = useAuth();
 
   // 정렬된 조합 목록
   const sortedCombos = useMemo(() => {
@@ -511,7 +508,9 @@ const MyPage = () => {
             {/* 프로필 카드 */}
             <div className="mt-60 h-100 rounded-card border border-blue-300 flex items-center justify-center gap-30">
               <Logo className="w-48 h-48 flex-shrink-0" />
-              <p className="font-heading-2 text-black">{userProfile?.username ?? '000'} 님</p>
+              <p className="font-heading-2 text-black">
+                {isAuthLoading ? '불러오는 중...' : `${userProfile?.username ?? '000'} 님`}
+              </p>
             </div>
 
             {/* 사용자 정보 */}
@@ -529,7 +528,9 @@ const MyPage = () => {
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
                 <div className="flex flex-wrap gap-12 content-start">
-                  <RoundedLifestyleTag label={userProfile?.lifestyleList?.[0] ?? ''} />
+                  {userProfile?.lifestyleList?.[0] && (
+                    <RoundedLifestyleTag label={userProfile.lifestyleList[0]} />
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/my/MyPage.tsx
+++ b/src/pages/my/MyPage.tsx
@@ -529,11 +529,7 @@ const MyPage = () => {
               <div className="flex items-center gap-24">
                 <p className="font-body-2-sm text-black whitespace-nowrap">라이프스타일</p>
                 <div className="flex flex-wrap gap-12 content-start">
-                  <RoundedLifestyleTag
-                    label={
-                      (userProfile?.lifestyleList?.[0] ?? '').replace(/^#\s*/, '')
-                    }
-                  />
+                  <RoundedLifestyleTag label={userProfile?.lifestyleList?.[0] ?? ''} />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #129 

## 🔍 구현한 내용
**마이페이지 유저 프로필 조회 API 연동**

- useGetUserProfile를 통해 React Query 기반으로 유저 프로필 조회하도록 연동했습니다.
- useQueryClient를 사용해 USER_PROFILE 쿼리 캐시 데이터를 활용하도록 구성했습니다.

**MyPage UI에 유저 프로필 데이터 바인딩**
- 사용자명, 이메일, 가입일, 라이프스타일 태그 등을 프로필 API 응답 기반으로 렌더링하도록 수정했습니다.
- RecentlyViewedFloating 컴포넌트에도 유저 이름을 프로필 데이터 기준으로 전달하도록 반영했습니다.

**RoundedLifestyleTag 라벨 렌더링 수정**
- 태그 컴포넌트에서 label이 정상적으로 렌더링되도록 JSX 구조를 정리했습니다.


## 📸 스크린샷 or 실행 영상

- 프로필 수정 API (연동 시작x) Swagger를 통해 수정한 값이 화면에 반영

https://github.com/user-attachments/assets/a6e1cb5e-55cd-4873-807b-495ff435f435



- 로그아웃 후 다른 계정으로 로그인 시 유저 프로필 정보가 정상적으로 갱신

https://github.com/user-attachments/assets/adc1100b-6ea2-4653-b3b1-e7d6633933ba





## 📢 리뷰어에게
- files changed에서 줄바꿈 및 prettier 설정 차이로 인한 diff가 다소 보이는데, 해당 부분은 무시해주시고 유저 프로필 API 연동 및 쿼리 캐시 활용 부분 위주로 봐주시면 될 것 같습니다.


