### PR TITLE
feat: 프로필 수정 API 연동

### DIFF
--- a/src/apis/mypage/patchEditProfile.ts
+++ b/src/apis/mypage/patchEditProfile.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/apis/axios/axios';
 import { useMutation } from '@tanstack/react-query';
-import type { EditProfileRequest, EditProfileResponse } from '@/types/mypage/editprofile';
+import type { EditProfileRequest, EditProfileResponse } from '@/types/mypage/editProfile';
 
 export const patchEditProfile = async (
   payload: EditProfileRequest

--- a/src/apis/mypage/patchEditProfile.ts
+++ b/src/apis/mypage/patchEditProfile.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import { useMutation } from '@tanstack/react-query';
+import type { EditProfileRequest, EditProfileResponse } from '@/types/mypage/editProfile';
+
+export const patchEditProfile = async (
+  payload: EditProfileRequest
+): Promise<EditProfileResponse> => {
+  const { data } = await axiosInstance.patch<EditProfileResponse>(
+    '/api/mypage/user-profile',
+    payload
+  );
+  return data;
+};
+
+export const usePatchEditProfile = () => {
+  return useMutation({
+    mutationFn: patchEditProfile,
+  });
+};

--- a/src/apis/mypage/patchEditProfile.ts
+++ b/src/apis/mypage/patchEditProfile.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/apis/axios/axios';
 import { useMutation } from '@tanstack/react-query';
-import type { EditProfileRequest, EditProfileResponse } from '@/types/mypage/editProfile';
+import type { EditProfileRequest, EditProfileResponse } from '@/types/mypage/editprofile';
 
 export const patchEditProfile = async (
   payload: EditProfileRequest

--- a/src/components/Setting/LifestyleSelectSection.tsx
+++ b/src/components/Setting/LifestyleSelectSection.tsx
@@ -1,16 +1,15 @@
 import { useCallback } from 'react';
 import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
-import { LIFESTYLE_TAGS, type LifestyleLabel } from '@/constants/lifestyle';
-
+import { LIFESTYLE_DISPLAY_TAGS, type LifestyleDisplayTag } from '@/constants/lifestyle';
 type LifestyleSelectSectionProps = {
-  value: LifestyleLabel[];
-  onChange: (next: LifestyleLabel[]) => void;
+  value: LifestyleDisplayTag[];
+  onChange: (next: LifestyleDisplayTag[]) => void;
 };
 
 const LifestyleSelectSection = ({ value, onChange }: LifestyleSelectSectionProps) => {
   const handleToggle = useCallback(
     (label: string, nextSelected: boolean) => {
-      const tag = label as LifestyleLabel;
+      const tag = label as LifestyleDisplayTag;
       if (nextSelected) {
         onChange([tag]);
         return;
@@ -21,21 +20,11 @@ const LifestyleSelectSection = ({ value, onChange }: LifestyleSelectSectionProps
   );
 
   return (
-    <div
-      className="
-        flex flex-col items-start
-        gap-10
-        pt-16 px-30 pb-20
-        self-stretch
-        rounded-card
-        bg-white
-        border-shadow-black
-      "
-    >
+    <div className="flex flex-col items-start gap-10 pt-16 px-30 pb-20 self-stretch rounded-card bg-white border-shadow-black">
       <div className="flex flex-col gap-16 self-stretch">
         <p className="font-body-3-sm text-black">라이프스타일</p>
         <div className="flex flex-wrap items-center content-center gap-12 self-stretch">
-          {LIFESTYLE_TAGS.map((label) => (
+          {LIFESTYLE_DISPLAY_TAGS.map((label) => (
             <RoundedLifestyleTag
               key={label}
               label={label}

--- a/src/components/Setting/LifestyleSelectSection.tsx
+++ b/src/components/Setting/LifestyleSelectSection.tsx
@@ -1,25 +1,16 @@
 import { useCallback } from 'react';
 import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
-
-export const TAGS = [
-  'Office',
-  'Study',
-  'Tour/portability',
-  'Developer',
-  'Game',
-  'Video-editing',
-] as const;
-export type Tag = (typeof TAGS)[number];
+import { LIFESTYLE_TAGS, type LifestyleLabel } from '@/constants/lifestyle';
 
 type LifestyleSelectSectionProps = {
-  value: Tag[];
-  onChange: (next: Tag[]) => void;
+  value: LifestyleLabel[];
+  onChange: (next: LifestyleLabel[]) => void;
 };
 
 const LifestyleSelectSection = ({ value, onChange }: LifestyleSelectSectionProps) => {
   const handleToggle = useCallback(
     (label: string, nextSelected: boolean) => {
-      const tag = label as Tag;
+      const tag = label as LifestyleLabel;
       if (nextSelected) {
         onChange([tag]);
         return;
@@ -44,7 +35,7 @@ const LifestyleSelectSection = ({ value, onChange }: LifestyleSelectSectionProps
       <div className="flex flex-col gap-16 self-stretch">
         <p className="font-body-3-sm text-black">라이프스타일</p>
         <div className="flex flex-wrap items-center content-center gap-12 self-stretch">
-          {TAGS.map((label) => (
+          {LIFESTYLE_TAGS.map((label) => (
             <RoundedLifestyleTag
               key={label}
               label={label}

--- a/src/constants/lifestyle.ts
+++ b/src/constants/lifestyle.ts
@@ -52,3 +52,9 @@ export const LIFESTYLE_TAG_IMAGE_MAP = Object.fromEntries(
 export const LIFESTYLE_LABEL_TO_TAGKEY = Object.fromEntries(
   Object.entries(LIFESTYLE_CONFIG).map(([label, { tagKey }]) => [label, tagKey])
 ) as Record<LifestyleLabel, LifestyleTagKey>;
+
+// label -> tag
+export type LifestyleDisplayTag = `# ${LifestyleLabel}`;
+export const LIFESTYLE_DISPLAY_TAGS = LIFESTYLE_TAGS.map(
+  (t) => `# ${t}` as const
+) as LifestyleDisplayTag[];

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,7 +20,7 @@ export type UserProfile = UserProfileResult;
 
 export const useAuth = () => {
   const hasToken = hasAuthTokens();
-  const { data: user, isLoading } = useGetUserProfile();
+  const { data: user, isLoading, refetch } = useGetUserProfile();
 
   // 인증 관련 초기 로딩 상태
   // - 토큰이 있을 때: userProfile 조회 중 (isLoading = true)
@@ -37,5 +37,6 @@ export const useAuth = () => {
     user: user ?? null,
     isAuthLoading,
     hasToken,
+    refetchUserProfile: refetch,
   };
 };

--- a/src/pages/my/settings/ProfileEditPage.tsx
+++ b/src/pages/my/settings/ProfileEditPage.tsx
@@ -1,4 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 import NicknameEditSection from '@/components/Setting/NicknameEditSection';
 import EmailSection from '@/components/Setting/EmailSection';
 import PasswordSettingSection from '@/components/Setting/PasswordSettingSection';
@@ -6,49 +8,45 @@ import LifestyleSelectSection from '@/components/Setting/LifestyleSelectSection'
 import PrimaryButton from '@/components/Button/PrimaryButton';
 import { validateNickname } from '@/utils/validateNickname';
 import BackIcon from '@/assets/icons/back_gray.svg?react';
-import { useNavigate } from 'react-router-dom';
-
-type AuthProvider = 'GENERAL' | 'HYBRID' | 'GOOGLE';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { LIFESTYLE_TAGS, type LifestyleLabel } from '@/constants/lifestyle';
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
-
-  // TODO: API 연동
-  const initialNickname = '000';
-  const initialEmail = 'example@devicelife.com';
-  const initialLifestyles: string[] = [];
-
-  const [authProvider] = useState<AuthProvider>('GENERAL');
-
-  const TAGS = [
-    'Office',
-    'Study',
-    'Tour/portability',
-    'Developer',
-    'Game',
-    'Video-editing',
-  ] as const;
-  type Tag = (typeof TAGS)[number];
-
+  const { user, isAuthLoading } = useAuth();
+  const serverLifestyleLabel = useMemo((): LifestyleLabel | null => {
+    const raw = user?.lifestyleList?.[0];
+    if (!raw) return null;
+    const normalized = raw.replace(/^#\s*/, '') as LifestyleLabel;
+    return LIFESTYLE_TAGS.includes(normalized) ? normalized : null;
+  }, [user]);
+  const initialNickname = user?.username ?? '000';
+  const initialEmail = user?.email ?? 'example@devicelife.com';
+  const initialLifestyles = serverLifestyleLabel ? [serverLifestyleLabel] : [];
+  const authProvider = user?.authProvider ?? 'GENERAL';
   const [nickname, setNickname] = useState(initialNickname);
-  const [lifestyles, setLifestyles] = useState<Tag[]>([]);
+  const [lifestyles, setLifestyles] = useState<LifestyleLabel[]>(initialLifestyles);
 
+  useEffect(() => {
+    if (!user) return;
+    setNickname(user.username ?? '000');
+    setLifestyles(serverLifestyleLabel ? [serverLifestyleLabel] : []);
+  }, [user, serverLifestyleLabel]);
+
+  const nicknameError = validateNickname(nickname);
+  const isLifestyleValid = lifestyles.length === 1;
   const isDirty = useMemo(() => {
     if (nickname !== initialNickname) return true;
     if (lifestyles.join(',') !== initialLifestyles.join(',')) return true;
     return false;
-  }, [nickname, lifestyles]);
+  }, [nickname, lifestyles, initialNickname, initialLifestyles]);
 
-  const nicknameError = validateNickname(nickname);
-  const isLifestyleValid = lifestyles.length === 1;
+  if (isAuthLoading) return <LoadingSpinner />;
 
   return (
     <div className="flex flex-col gap-72 mx-auto w-560 mt-92 mb-92">
       <div className="flex flex-row gap-20 h-40 items-center">
-        <BackIcon
-          className="w-34 h-34 cursor-pointer"
-          onClick={() => navigate('/my')}
-        />
+        <BackIcon className="w-34 h-34 cursor-pointer" onClick={() => navigate('/my')} />
         <p className="font-heading-2 text-black">프로필 수정</p>
       </div>
       <div className="flex flex-col gap-20 w-560">

--- a/src/pages/my/settings/ProfileEditPage.tsx
+++ b/src/pages/my/settings/ProfileEditPage.tsx
@@ -14,8 +14,8 @@ import { LIFESTYLE_DISPLAY_TAGS, type LifestyleDisplayTag } from '@/constants/li
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
-  const { user, isAuthLoading } = useAuth();
-  const { mutate: patchEditProfile, isPending } = usePatchEditProfile();
+  const { user, isAuthLoading, refetchUserProfile } = useAuth();
+  const { mutate: patchProfile, isPending } = usePatchEditProfile();
   const serverLifestyle = useMemo<LifestyleDisplayTag[]>(() => {
     const raw = user?.lifestyleList ?? [];
     return raw.filter((t): t is LifestyleDisplayTag =>
@@ -45,6 +45,21 @@ const ProfileEditPage = () => {
   }, [nickname, lifestyles, initialNickname, initialLifestyles]);
 
 
+  const handleSave = () => {
+    patchProfile(
+      {
+        username: nickname,
+        email: initialEmail,
+        lifestyleList: lifestyles,
+      },
+      {
+        onSuccess: async () => {
+          await refetchUserProfile();
+        },
+      }
+    );
+  };
+
   if (isAuthLoading) return <LoadingSpinner />;
 
   return (
@@ -63,6 +78,7 @@ const ProfileEditPage = () => {
         <PrimaryButton
           className="w-400 bg-blue-600 hover:bg-blue-500 disabled:hover:bg-gray-300"
           text={isPending ? '저장 중...' : '저장하기'}
+          onClick={handleSave}
           disabled={!isDirty || !!nicknameError || !isLifestyleValid || isPending}
         />
       </div>

--- a/src/pages/my/settings/ProfileEditPage.tsx
+++ b/src/pages/my/settings/ProfileEditPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { usePatchEditProfile } from '@/apis/mypage/patchEditProfile';
 import NicknameEditSection from '@/components/Setting/NicknameEditSection';
 import EmailSection from '@/components/Setting/EmailSection';
 import PasswordSettingSection from '@/components/Setting/PasswordSettingSection';
@@ -9,29 +10,31 @@ import PrimaryButton from '@/components/Button/PrimaryButton';
 import { validateNickname } from '@/utils/validateNickname';
 import BackIcon from '@/assets/icons/back_gray.svg?react';
 import LoadingSpinner from '@/components/LoadingSpinner';
-import { LIFESTYLE_TAGS, type LifestyleLabel } from '@/constants/lifestyle';
+import { LIFESTYLE_DISPLAY_TAGS, type LifestyleDisplayTag } from '@/constants/lifestyle';
 
 const ProfileEditPage = () => {
   const navigate = useNavigate();
   const { user, isAuthLoading } = useAuth();
-  const serverLifestyleLabel = useMemo((): LifestyleLabel | null => {
-    const raw = user?.lifestyleList?.[0];
-    if (!raw) return null;
-    const normalized = raw.replace(/^#\s*/, '') as LifestyleLabel;
-    return LIFESTYLE_TAGS.includes(normalized) ? normalized : null;
+  const { mutate: patchEditProfile, isPending } = usePatchEditProfile();
+  const serverLifestyle = useMemo<LifestyleDisplayTag[]>(() => {
+    const raw = user?.lifestyleList ?? [];
+    return raw.filter((t): t is LifestyleDisplayTag =>
+      LIFESTYLE_DISPLAY_TAGS.includes(t as LifestyleDisplayTag)
+    );
   }, [user]);
+
   const initialNickname = user?.username ?? '000';
   const initialEmail = user?.email ?? 'example@devicelife.com';
-  const initialLifestyles = serverLifestyleLabel ? [serverLifestyleLabel] : [];
+  const initialLifestyles = serverLifestyle; 
   const authProvider = user?.authProvider ?? 'GENERAL';
   const [nickname, setNickname] = useState(initialNickname);
-  const [lifestyles, setLifestyles] = useState<LifestyleLabel[]>(initialLifestyles);
+  const [lifestyles, setLifestyles] = useState<LifestyleDisplayTag[]>(initialLifestyles);
 
   useEffect(() => {
     if (!user) return;
     setNickname(user.username ?? '000');
-    setLifestyles(serverLifestyleLabel ? [serverLifestyleLabel] : []);
-  }, [user, serverLifestyleLabel]);
+    setLifestyles(serverLifestyle);
+  }, [user, serverLifestyle]);
 
   const nicknameError = validateNickname(nickname);
   const isLifestyleValid = lifestyles.length === 1;
@@ -40,6 +43,7 @@ const ProfileEditPage = () => {
     if (lifestyles.join(',') !== initialLifestyles.join(',')) return true;
     return false;
   }, [nickname, lifestyles, initialNickname, initialLifestyles]);
+
 
   if (isAuthLoading) return <LoadingSpinner />;
 
@@ -58,8 +62,8 @@ const ProfileEditPage = () => {
       <div className="flex justify-center">
         <PrimaryButton
           className="w-400 bg-blue-600 hover:bg-blue-500 disabled:hover:bg-gray-300"
-          text="저장하기"
-          disabled={!isDirty || !!nicknameError || !isLifestyleValid}
+          text={isPending ? '저장 중...' : '저장하기'}
+          disabled={!isDirty || !!nicknameError || !isLifestyleValid || isPending}
         />
       </div>
     </div>

--- a/src/types/mypage/editProfile.ts
+++ b/src/types/mypage/editProfile.ts
@@ -1,0 +1,17 @@
+import type { CommonResponse } from '@/types/common';
+
+// 프로필 수정 Request
+export type EditProfileRequest = {
+  username: string;
+  email: string;
+  lifestyleList: string[];
+};
+
+export type EditProfileResult = {
+  username: string;
+  email: string;
+  lifestyleList: string[];
+};
+
+// 프로필 수정 Response
+export type EditProfileResponse = CommonResponse<EditProfileResult>;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #131 

## 🔍 구현한 내용
**프로필 수정 PATCH API 연동**

**라이프스타일 태그 표기(# ...)를 서버 포맷 그대로 통일**
  - `LIFESTYLE_DISPLAY_TAGS` 기반 렌더링/토글

**프로필 수정 페이지(ProfileEditPage) 데이터 흐름 개선**
  - useAuth()로 구독 중인 user를 초기값으로 세팅
  - 서버에서 내려오는 lifestyleList(예: # Game)를 LIFESTYLE_DISPLAY_TAGS 기준으로 필터링해 활성화
  - 저장 시 `usePatchEditProfile` 호출
  - 성공 시 `refetchUserProfile()`로 유저 프로필 캐시 갱신되도록 처리
  - 저장 중 버튼 텍스트/disabled 처리`(isPending)`

**useAuth 개선**
  - `useGetUserProfile()`의 `refetch`를 노출해서, 수정 후 즉시 최신 프로필 재조회 가능하게 했습니다.



## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/f335e013-9eb1-45b7-9114-5d0cd1756bd6



## 📢 리뷰어에게
라이프스타일 태그는 최대 1개 선택이 맞습니다. 다만 서버는 lifestyleList에 여러 값 전달이 가능한 형태라, 백엔드 담당자님께 1개만 허용되도록 스펙 수정 요청 드린 상태입니다. 프론트에서는 우선 단일 선택만 가능하도록 UI에서 제한해두었습니다!