### PR TITLE
feat: 리프레시 토큰 저장 방식 변경 및 소셜 로그인 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@react-oauth/google": "^0.13.4",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-query-devtools": "^5.91.2",
         "axios": "^1.13.2",
@@ -74,7 +75,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1052,6 +1052,16 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.4.tgz",
+      "integrity": "sha512-hGKyNEH+/PK8M0sFEuo3MAEk0txtHpgs94tDQit+s2LXg7b6z53NtzHfqDvoB2X8O6lGB+FRg80hY//X6hfD+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1565,7 +1575,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -1919,7 +1928,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -2013,7 +2021,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2024,7 +2031,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2084,7 +2090,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2336,7 +2341,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2459,7 +2463,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2894,7 +2897,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2955,7 +2957,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4165,7 +4166,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4218,7 +4218,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4263,7 +4262,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4273,7 +4271,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4286,7 +4283,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -4610,7 +4606,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4697,7 +4692,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4833,7 +4827,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@react-oauth/google": "^0.13.4",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-devtools": "^5.91.2",
     "axios": "^1.13.2",

--- a/src/apis/auth/postLogin.ts
+++ b/src/apis/auth/postLogin.ts
@@ -1,9 +1,10 @@
-import { axiosInstance } from '@/apis/axios/axios';
+import { cookieAxiosInstance } from '@/apis/axios/cookieAxios';
 import type { LoginRequest, LoginResponse } from '@/types/auth/login';
 import { useMutation } from '@tanstack/react-query';
 
 export const postLogin = async (payload: LoginRequest): Promise<LoginResponse> => {
-  const { data } = await axiosInstance.post<LoginResponse>('/api/auth/login', payload);
+  // refreshToken은 httpOnly 쿠키로 자동 수신됨
+  const { data } = await cookieAxiosInstance.post<LoginResponse>('/api/auth/login', payload);
   return data;
 };
 

--- a/src/apis/auth/postLogout.ts
+++ b/src/apis/auth/postLogout.ts
@@ -1,19 +1,12 @@
-import { axiosInstance } from '@/apis/axios/axios';
+import { cookieAxiosInstance } from '@/apis/axios/cookieAxios';
 import type { LogoutResponse } from '@/types/auth/logout';
 import { useMutation } from '@tanstack/react-query';
-import { getRefreshToken } from '@/utils/authStorage';
 
 export const postLogout = async (): Promise<LogoutResponse> => {
-  const refreshToken = getRefreshToken();
-
-  const { data } = await axiosInstance.post<LogoutResponse>(
+  // refreshToken은 httpOnly 쿠키로 자동 전송됨
+  const { data } = await cookieAxiosInstance.post<LogoutResponse>(
     '/api/auth/logout',
-    {},
-    {
-      headers: {
-        refreshToken,
-      },
-    }
+    {}
   );
   return data;
 };

--- a/src/apis/auth/postRefresh.ts
+++ b/src/apis/auth/postRefresh.ts
@@ -1,16 +1,12 @@
-import { refreshAxiosInstance } from '@/apis/axios/refreshAxios';
+import { cookieAxiosInstance } from '@/apis/axios/cookieAxios';
 import type { RefreshTokenResponse } from '@/types/auth/refresh';
 import { useMutation } from '@tanstack/react-query';
 
-export const postRefresh = async (refreshToken: string): Promise<RefreshTokenResponse> => {
-  const { data } = await refreshAxiosInstance.post<RefreshTokenResponse>(
+export const postRefresh = async (): Promise<RefreshTokenResponse> => {
+  // refreshToken은 httpOnly 쿠키로 자동 전송됨
+  const { data } = await cookieAxiosInstance.post<RefreshTokenResponse>(
     '/api/auth/refresh',
-    {},
-    {
-      headers: {
-        refreshToken,
-      },
-    }
+    {}
   );
   return data;
 };

--- a/src/apis/axios/axios.ts
+++ b/src/apis/axios/axios.ts
@@ -7,7 +7,7 @@ const baseURL = import.meta.env.VITE_SERVER_API_URL;
 
 export const axiosInstance = axios.create({
   baseURL,
-  withCredentials: true, // 쿠키/세션 자동 포함
+  withCredentials: false, // 기본적으로 쿠키 미포함 (쿠키 필요한 API는 cookieAxiosInstance 사용)
 });
 
 // 요청 인터셉터 설정

--- a/src/apis/axios/cookieAxios.ts
+++ b/src/apis/axios/cookieAxios.ts
@@ -1,0 +1,10 @@
+// 쿠키가 필요한 API 전용 axios 인스턴스 (인터셉터 없음)
+
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_SERVER_API_URL;
+
+export const cookieAxiosInstance = axios.create({
+  baseURL,
+  withCredentials: true, // 쿠키/세션 자동 포함
+});

--- a/src/apis/axios/interceptors.ts
+++ b/src/apis/axios/interceptors.ts
@@ -3,23 +3,19 @@
  *
  * [401 에러 처리 흐름]
  * 1. 401 에러 발생
- * 2. refreshToken 존재 확인
- *    - 없으면: 로그인 페이지로 리다이렉트
- *    - 있으면: 토큰 갱신 시도
+ * 2. 토큰 갱신 시도 (refreshToken은 httpOnly 쿠키로 자동 전송됨)
  * 3. 토큰 갱신 (refreshPromise)
- *    - 성공: 새 토큰으로 원래 요청 재시도
- *    - 실패: 로그인 페이지로 리다이렉트
+ *    - 성공: 새 accessToken으로 원래 요청 재시도
+ *    - 실패: 로그인 페이지로 리다이렉트 (refreshToken 만료 또는 없음)
  * 4. 동시 요청 처리: 여러 요청이 동시에 401을 받으면 refreshPromise를 공유하여 토큰 갱신은 1번만 수행
 */
 import type { InternalAxiosRequestConfig, AxiosInstance } from 'axios';
 import {
   getAccessToken,
-  getRefreshToken,
   setAuthTokens,
   clearAuthTokens,
 } from '@/utils/authStorage';
-import { refreshAxiosInstance } from '@/apis/axios/refreshAxios';
-import type { RefreshTokenResponse } from '@/types/auth/refresh';
+import { postRefresh } from '@/apis/auth/postRefresh';
 import { setAuthorizationHeader } from '@/utils/setAuthorizationHeader';
 import { ROUTES } from '@/constants/routes';
 
@@ -102,18 +98,7 @@ export const setupResponseInterceptor = (instance: AxiosInstance) => {
       // 재시도 플래그 설정 (무한루프 방지)
       originalRequest._retry = true;
 
-
-
-      // [2] refreshToken 확인
-      const refreshToken = getRefreshToken();
-
-      if (!refreshToken) {
-        redirectToLoginOnce();
-        return Promise.reject(error);
-      }
-
-
-      // [3] 이미 다른 요청이 토큰 갱신 중이면 그 결과를 기다림
+      // [2] 이미 다른 요청이 토큰 갱신 중이면 그 결과를 기다림
       if (refreshPromise) {
         try {
           const newToken = await refreshPromise;
@@ -126,34 +111,21 @@ export const setupResponseInterceptor = (instance: AxiosInstance) => {
       }
 
 
-      // [4] 토큰 갱신 Promise 생성 및 실행
-      //     - try: 토큰 갱신 API 호출 → 성공 시 새 토큰 반환
+      // [3] 토큰 갱신 Promise 생성 및 실행
+      //     - try: 토큰 갱신 API 호출 (refreshToken은 httpOnly 쿠키로 자동 전송) → 성공 시 새 accessToken 반환
       //     - catch: 실패 시 로그인 리다이렉트 → 에러 re-throw (외부 catch로 전파)
       //     - finally: 성공/실패 관계없이 refreshPromise 초기화
       refreshPromise = (async () => {
         try {
-          const { data } = await refreshAxiosInstance.post<RefreshTokenResponse>(
-            '/api/auth/refresh',
-            {},
-            {
-              headers: {
-                refreshToken,
-              },
-            }
-          );
+          const data = await postRefresh();
 
           if (!data?.result?.accessToken) {
             throw new Error('토큰 재발급 응답이 올바르지 않습니다.');
           }
 
-          const currentRefreshToken = getRefreshToken();
-          if (!currentRefreshToken) {
-            throw new Error('Refresh token이 저장소에서 사라졌습니다.');
-          }
-
+          // 새 accessToken 저장 (refreshToken은 httpOnly 쿠키로 서버에서 관리)
           setAuthTokens({
             accessToken: data.result.accessToken,
-            refreshToken: currentRefreshToken,
           });
 
           return data.result.accessToken;
@@ -165,7 +137,7 @@ export const setupResponseInterceptor = (instance: AxiosInstance) => {
         }
       })();
 
-      // [5] 토큰 갱신 결과에 따라 원래 요청 재시도 또는 에러 반환
+      // [4] 토큰 갱신 결과에 따라 원래 요청 재시도 또는 에러 반환
       //     - 성공: 새 토큰으로 원래 요청 재시도
       //     - 실패: [4]의 catch에서 이미 리다이렉트 처리됨, 여기서는 에러만 전달
       try {

--- a/src/apis/axios/interceptors.ts
+++ b/src/apis/axios/interceptors.ts
@@ -12,8 +12,8 @@
 import type { InternalAxiosRequestConfig, AxiosInstance } from 'axios';
 import {
   getAccessToken,
-  setAuthTokens,
-  clearAuthTokens,
+  setAccessToken,
+  clearAccessToken,
 } from '@/utils/authStorage';
 import { postRefresh } from '@/apis/auth/postRefresh';
 import { setAuthorizationHeader } from '@/utils/setAuthorizationHeader';
@@ -38,7 +38,7 @@ const redirectToLoginOnce = () => {
   if (isRedirectingToLogin) return;
 
   isRedirectingToLogin = true;
-  clearAuthTokens();
+  clearAccessToken();
   window.location.href = ROUTES.auth.login;
 };
 
@@ -124,9 +124,7 @@ export const setupResponseInterceptor = (instance: AxiosInstance) => {
           }
 
           // 새 accessToken 저장 (refreshToken은 httpOnly 쿠키로 서버에서 관리)
-          setAuthTokens({
-            accessToken: data.result.accessToken,
-          });
+          setAccessToken(data.result.accessToken);
 
           return data.result.accessToken;
         } catch (refreshError) {

--- a/src/apis/axios/refreshAxios.ts
+++ b/src/apis/axios/refreshAxios.ts
@@ -1,9 +1,0 @@
-// refresh 전용 axios 인스턴스 (인터셉터 없음)
-
-import axios from 'axios';
-
-const baseURL = import.meta.env.VITE_SERVER_API_URL;
-
-export const refreshAxiosInstance = axios.create({
-  baseURL,
-});

--- a/src/apis/findCredential/postFindPassword.ts
+++ b/src/apis/findCredential/postFindPassword.ts
@@ -1,4 +1,5 @@
 import { axiosInstance } from '@/apis/axios/axios';
+import { cookieAxiosInstance } from '@/apis/axios/cookieAxios';
 import type {
   SendMailRequest,
   SendMailResponse,
@@ -31,7 +32,7 @@ export const usePostSendMail = () => {
 export const postVerifyCode = async (
   payload: VerifyCodeRequest
 ): Promise<VerifyCodeResponse> => {
-  const { data } = await axiosInstance.post<VerifyCodeResponse>(
+  const { data } = await cookieAxiosInstance.post<VerifyCodeResponse>(
     '/api/find-credential/find-password/verify-code',
     payload
   );
@@ -49,7 +50,7 @@ export const usePostVerifyCode = () => {
 export const postResetPassword = async (
   payload: ResetPasswordRequest
 ): Promise<ResetPasswordResponse> => {
-  const { data } = await axiosInstance.post<ResetPasswordResponse>(
+  const { data } = await cookieAxiosInstance.post<ResetPasswordResponse>(
     '/api/find-credential/find-password/reset',
     payload
   );

--- a/src/apis/mypage/getUserProfile.ts
+++ b/src/apis/mypage/getUserProfile.ts
@@ -2,7 +2,7 @@ import { axiosInstance } from '@/apis/axios/axios';
 import type { UserProfileResponse, UserProfileResult } from '@/types/mypage/user';
 import { useQuery } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
-import { hasAuthTokens } from '@/utils/authStorage';
+import { hasAccessToken } from '@/utils/authStorage';
 
 // 유저 정보 조회 API
 export const getUserProfile = async (): Promise<UserProfileResult | undefined> => {
@@ -12,7 +12,7 @@ export const getUserProfile = async (): Promise<UserProfileResult | undefined> =
 
 // 유저 정보 조회 Query
 export const useGetUserProfile = () => {
-  const hasTokens = hasAuthTokens();
+  const hasTokens = hasAccessToken();
 
   return useQuery<UserProfileResult | undefined>({
     queryKey: [queryKey.USER_PROFILE],

--- a/src/components/Button/GoogleLoginButton.tsx
+++ b/src/components/Button/GoogleLoginButton.tsx
@@ -1,12 +1,11 @@
 import GoogleLogo from '@/assets/logos/google_noborder.svg?react';
 import clsx from 'clsx';
+import { OAUTH } from '@/constants/auth';
 
 type GoogleLoginButtonProps = {
   onClick?: () => void;
   className?: string;
 };
-
-const GOOGLE_OAUTH_URL = 'https://api.devicelife.site/oauth2/authorization/google';
 
 const GoogleLoginButton = ({ onClick, className }: GoogleLoginButtonProps) => {
   const handleClick = () => {
@@ -14,7 +13,7 @@ const GoogleLoginButton = ({ onClick, className }: GoogleLoginButtonProps) => {
       onClick();
     } else {
       // Google OAuth 인증 페이지로 이동
-      window.location.href = GOOGLE_OAUTH_URL;
+      window.location.href = OAUTH.google;
     }
   };
 

--- a/src/components/Button/GoogleLoginButton.tsx
+++ b/src/components/Button/GoogleLoginButton.tsx
@@ -6,11 +6,22 @@ type GoogleLoginButtonProps = {
   className?: string;
 };
 
+const GOOGLE_OAUTH_URL = 'https://api.devicelife.site/oauth2/authorization/google';
+
 const GoogleLoginButton = ({ onClick, className }: GoogleLoginButtonProps) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    } else {
+      // Google OAuth 인증 페이지로 이동
+      window.location.href = GOOGLE_OAUTH_URL;
+    }
+  };
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={handleClick}
       className={clsx(
         'flex items-center gap-24',
         'py-8 pl-0 pr-8',

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,3 @@
+export const OAUTH = {
+  google: `${import.meta.env.VITE_SERVER_API_URL}/oauth2/authorization/google`,
+} as const;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -16,6 +16,9 @@ export const ROUTES = {
       account: '/auth/signup/account',
       profile: '/auth/signup/profile',
     },
+    callback: {
+      google: '/auth/callback/google',
+    },
   },
 
   // onboarding

--- a/src/constants/tokenKey.ts
+++ b/src/constants/tokenKey.ts
@@ -1,3 +1,3 @@
 // 토큰 관련 키 상수
 export const ACCESS_TOKEN = 'ACCESS_TOKEN';
-export const REFRESH_TOKEN = 'REFRESH_TOKEN';
+

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useGetUserProfile } from '@/apis/mypage/getUserProfile';
-import { hasAuthTokens } from '@/utils/authStorage';
+import { hasAccessToken } from '@/utils/authStorage';
 import type { UserProfileResult } from '@/types/mypage/user';
 
 // UserProfile 타입 별칭 (UserProfileResult와 동일)
@@ -19,7 +19,7 @@ export type UserProfile = UserProfileResult;
  */
 
 export const useAuth = () => {
-  const hasToken = hasAuthTokens();
+  const hasToken = hasAccessToken();
   const { data: user, isLoading, refetch } = useGetUserProfile();
 
   // 인증 관련 초기 로딩 상태

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -22,7 +22,6 @@ export const useLogin = () => {
 
     await finalizeLogin(
       res.result.accessToken,
-      res.result.refreshToken,
       queryClient
     );
   };

--- a/src/pages/auth/GoogleCallbackPage.tsx
+++ b/src/pages/auth/GoogleCallbackPage.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { postRefresh } from '@/apis/auth/postRefresh';
 import { finalizeLogin } from '@/utils/finalizeLogin';
-import { hasCompletedOnboarding } from '@/utils/authStorage';
 import { ROUTES } from '@/constants/routes';
 import { queryKey } from '@/constants/queryKey';
 import type { UserProfileResult } from '@/types/mypage/user';
@@ -12,42 +11,42 @@ import type { UserProfileResult } from '@/types/mypage/user';
 const GoogleCallbackPage = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const hasHandled = useRef(false);
 
   useEffect(() => {
-    const handleCallback = async () => {
+    // 이미 처리된 경우 종료(StrictMode 때문에 여러번 호출될 수 있음)
+    const run = async () => {
+      if (hasHandled.current) return;
+      hasHandled.current = true;
+
       try {
-        // 1. refreshToken을 통해 accessToken 발급받기
+        // 1) refreshToken 쿠키로 accessToken 발급
         const refreshResponse = await postRefresh();
+        const accessToken = refreshResponse?.result?.accessToken;
+        if (!accessToken) throw new Error('액세스 토큰을 받지 못했습니다.');
 
-        if (!refreshResponse?.result?.accessToken) {
-          throw new Error('액세스 토큰을 받지 못했습니다.');
-        }
-
-        const accessToken = refreshResponse.result.accessToken;
-
-        // 2. 받은 accessToken으로 프론트에서 로그인 상태 만들기
+        // 2) accessToken 저장 + 유저 캐시 세팅 (finalizeLogin 내부에서)
         await finalizeLogin(accessToken, queryClient);
 
-        // 3. 온보딩 완료 여부 확인 후 리다이렉트
-        const userProfile = queryClient.getQueryData<UserProfileResult>([
+        // 3) 캐시에서 유저 꺼내서 분기
+        const user = queryClient.getQueryData<UserProfileResult>([
           queryKey.USER_PROFILE,
         ]);
 
-        if (hasCompletedOnboarding(userProfile)) {
-          // 온보딩 완료: 홈으로 리다이렉트
+        // 온보딩 완료 여부 확인 후 리다이렉트
+        if (user?.isOnboardingCompleted) {
           navigate(ROUTES.home, { replace: true });
         } else {
-          // 온보딩 미완료: 온보딩 시작으로 리다이렉트
           navigate(ROUTES.onboarding.lifestyle, { replace: true });
         }
-      } catch (error) {
-        console.error('Google OAuth 콜백 처리 실패:', error);
+        // 실패 시 로그인 페이지로 리다이렉트
+      } catch {
         alert('로그인에 실패했습니다. 다시 시도해주세요.');
-        navigate(ROUTES.auth.login, { replace: true });
+        navigate(ROUTES.auth.login, { replace: true, });
       }
     };
 
-    handleCallback();
+    run();
   }, [navigate, queryClient]);
 
   return <LoadingSpinner />;

--- a/src/pages/auth/GoogleCallbackPage.tsx
+++ b/src/pages/auth/GoogleCallbackPage.tsx
@@ -1,9 +1,7 @@
+import LoadingSpinner from '@/components/LoadingSpinner';
+
 const GoogleCallbackPage = () => {
-  return (
-    <div className="flex flex-col items-center justify-center h-[calc(100vh-80px)]">
-      <p className="font-body-2-r text-gray-600">로그인 처리 중...</p>
-    </div>
-  );
+  return <LoadingSpinner />;
 };
 
 export default GoogleCallbackPage;

--- a/src/pages/auth/GoogleCallbackPage.tsx
+++ b/src/pages/auth/GoogleCallbackPage.tsx
@@ -1,6 +1,42 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import { postRefresh } from '@/apis/auth/postRefresh';
+import { finalizeLogin } from '@/utils/finalizeLogin';
+import { ROUTES } from '@/constants/routes';
 
 const GoogleCallbackPage = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        // 1. refreshToken을 통해 accessToken 발급받기
+        const refreshResponse = await postRefresh();
+
+        if (!refreshResponse?.result?.accessToken) {
+          throw new Error('액세스 토큰을 받지 못했습니다.');
+        }
+
+        const accessToken = refreshResponse.result.accessToken;
+
+        // 2. 받은 accessToken으로 프론트에서 로그인 상태 만들기
+        await finalizeLogin(accessToken, queryClient);
+
+        // 3. 성공 시 홈으로 리다이렉트
+        navigate(ROUTES.home, { replace: true });
+      } catch (error) {
+        console.error('Google OAuth 콜백 처리 실패:', error);
+        alert('로그인에 실패했습니다. 다시 시도해주세요.');
+        navigate(ROUTES.auth.login, { replace: true });
+      }
+    };
+
+    handleCallback();
+  }, [navigate, queryClient]);
+
   return <LoadingSpinner />;
 };
 

--- a/src/pages/auth/GoogleCallbackPage.tsx
+++ b/src/pages/auth/GoogleCallbackPage.tsx
@@ -4,7 +4,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { postRefresh } from '@/apis/auth/postRefresh';
 import { finalizeLogin } from '@/utils/finalizeLogin';
+import { hasCompletedOnboarding } from '@/utils/authStorage';
 import { ROUTES } from '@/constants/routes';
+import { queryKey } from '@/constants/queryKey';
+import type { UserProfileResult } from '@/types/mypage/user';
 
 const GoogleCallbackPage = () => {
   const navigate = useNavigate();
@@ -25,8 +28,18 @@ const GoogleCallbackPage = () => {
         // 2. 받은 accessToken으로 프론트에서 로그인 상태 만들기
         await finalizeLogin(accessToken, queryClient);
 
-        // 3. 성공 시 홈으로 리다이렉트
-        navigate(ROUTES.home, { replace: true });
+        // 3. 온보딩 완료 여부 확인 후 리다이렉트
+        const userProfile = queryClient.getQueryData<UserProfileResult>([
+          queryKey.USER_PROFILE,
+        ]);
+
+        if (hasCompletedOnboarding(userProfile)) {
+          // 온보딩 완료: 홈으로 리다이렉트
+          navigate(ROUTES.home, { replace: true });
+        } else {
+          // 온보딩 미완료: 온보딩 시작으로 리다이렉트
+          navigate(ROUTES.onboarding.lifestyle, { replace: true });
+        }
       } catch (error) {
         console.error('Google OAuth 콜백 처리 실패:', error);
         alert('로그인에 실패했습니다. 다시 시도해주세요.');

--- a/src/pages/auth/GoogleCallbackPage.tsx
+++ b/src/pages/auth/GoogleCallbackPage.tsx
@@ -1,0 +1,9 @@
+const GoogleCallbackPage = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-[calc(100vh-80px)]">
+      <p className="font-body-2-r text-gray-600">로그인 처리 중...</p>
+    </div>
+  );
+};
+
+export default GoogleCallbackPage;

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -30,7 +30,7 @@ import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePostComboDevice } from '@/apis/combo/postComboDevices';
 import { useGetUserProfile } from '@/apis/mypage/getUserProfile';
 import { useGetBrands } from '@/apis/devices/getBrands';
-import { hasAuthTokens, hasCompletedOnboarding } from '@/utils/authStorage';
+import { hasAccessToken, hasCompletedOnboarding } from '@/utils/authStorage';
 
 // 카테고리 ID를 API deviceType으로 변환
 const getCategoryDeviceType = (categoryId: number | null): string | undefined => {
@@ -54,7 +54,7 @@ const DeviceSearchPage = () => {
   const navigate = useNavigate();
 
   // 로그인 상태 확인
-  const isLoggedIn = hasAuthTokens();
+  const isLoggedIn = hasAccessToken();
 
   // 사용자 프로필 조회 (로그인 시에만 자동 실행)
   const { data: userProfile, isLoading: isProfileLoading } = useGetUserProfile();

--- a/src/routes/PublicRoutes.tsx
+++ b/src/routes/PublicRoutes.tsx
@@ -19,6 +19,7 @@ import FindPasswordPage from '@/pages/auth/FindPasswordPage';
 import SignupPage from '@/pages/auth/SignupPage';
 import SignupAccountPage from '@/pages/auth/SignupAccountPage';
 import SignupProfilePage from '@/pages/auth/SignupProfilePage';
+import GoogleCallbackPage from '@/pages/auth/GoogleCallbackPage';
 
 import NotFoundPage from '@/pages/NotFoundPage';
 
@@ -41,6 +42,9 @@ export const PublicRoutes = {
 
     // 조합 생성
     { path: 'combination/create', element: <CombinationCreatePage /> },
+
+    // OAuth 콜백 (단독, 가드 없음)
+    { path: 'auth/callback/google', element: <GoogleCallbackPage /> },
 
     // auth (로그인/회원가입/찾기)
     {

--- a/src/types/auth/login.ts
+++ b/src/types/auth/login.ts
@@ -10,6 +10,7 @@ export type LoginRequest = {
 export type LoginResult = {
   userId: number;
   accessToken: string;
+  refreshToken: null; // httpOnly 쿠키로만 전송되므로 응답에서는 항상 null
 };
 
 // 로그인 응답 타입

--- a/src/types/auth/login.ts
+++ b/src/types/auth/login.ts
@@ -10,7 +10,6 @@ export type LoginRequest = {
 export type LoginResult = {
   userId: number;
   accessToken: string;
-  refreshToken: string;
 };
 
 // 로그인 응답 타입

--- a/src/utils/authStorage.ts
+++ b/src/utils/authStorage.ts
@@ -1,4 +1,4 @@
-import { ACCESS_TOKEN, REFRESH_TOKEN} from '@/constants/tokenKey';
+import { ACCESS_TOKEN } from '@/constants/tokenKey';
 import type { UserProfileResult } from '@/types/mypage/user';
 
 // localStorage를 조작하는 유틸리티 함수
@@ -7,13 +7,11 @@ import type { UserProfileResult } from '@/types/mypage/user';
 // 토큰 저장 타입
 type AuthTokens = {
   accessToken: string;
-  refreshToken: string;
 };
 
-// 액세스 토큰과 리프레시 토큰을 한번에 저장
-export const setAuthTokens = ({ accessToken, refreshToken }: AuthTokens): void => {
+// 액세스 토큰 저장 (refreshToken은 httpOnly 쿠키로 관리)
+export const setAuthTokens = ({ accessToken }: AuthTokens): void => {
   localStorage.setItem(ACCESS_TOKEN, accessToken);
-  localStorage.setItem(REFRESH_TOKEN, refreshToken);
 };
 
 // 액세스 토큰 가져오기
@@ -21,22 +19,15 @@ export const getAccessToken = (): string | null => {
   return localStorage.getItem(ACCESS_TOKEN);
 };
 
-// 리프레시 토큰 가져오기
-export const getRefreshToken = (): string | null => {
-  return localStorage.getItem(REFRESH_TOKEN);
-};
-
-// 모든 인증 토큰 삭제
+// 모든 인증 토큰 삭제 (refreshToken은 서버에서 쿠키 삭제)
 export const clearAuthTokens = (): void => {
   localStorage.removeItem(ACCESS_TOKEN);
-  localStorage.removeItem(REFRESH_TOKEN);
 };
 
-// 토큰 존재 여부 체크
+// 토큰 존재 여부 체크 (accessToken만 확인, refreshToken은 httpOnly 쿠키)
 export const hasAuthTokens = (): boolean => {
   const accessToken = getAccessToken();
-  const refreshToken = getRefreshToken();
-  return !!(accessToken && refreshToken);
+  return !!accessToken;
 };
 
 // 온보딩 완료 여부 확인

--- a/src/utils/authStorage.ts
+++ b/src/utils/authStorage.ts
@@ -4,13 +4,8 @@ import type { UserProfileResult } from '@/types/mypage/user';
 // localStorage를 조작하는 유틸리티 함수
 // 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함
 
-// 토큰 저장 타입
-type AuthTokens = {
-  accessToken: string;
-};
-
 // 액세스 토큰 저장 (refreshToken은 httpOnly 쿠키로 관리)
-export const setAuthTokens = ({ accessToken }: AuthTokens): void => {
+export const setAccessToken = (accessToken: string): void => {
   localStorage.setItem(ACCESS_TOKEN, accessToken);
 };
 
@@ -19,13 +14,13 @@ export const getAccessToken = (): string | null => {
   return localStorage.getItem(ACCESS_TOKEN);
 };
 
-// 모든 인증 토큰 삭제 (refreshToken은 서버에서 쿠키 삭제)
-export const clearAuthTokens = (): void => {
+// 액세스 토큰 삭제 (refreshToken은 서버에서 쿠키 삭제)
+export const clearAccessToken = (): void => {
   localStorage.removeItem(ACCESS_TOKEN);
 };
 
-// 토큰 존재 여부 체크 (accessToken만 확인, refreshToken은 httpOnly 쿠키)
-export const hasAuthTokens = (): boolean => {
+// 액세스 토큰 존재 여부 체크 (refreshToken은 httpOnly 쿠키)
+export const hasAccessToken = (): boolean => {
   const accessToken = getAccessToken();
   return !!accessToken;
 };

--- a/src/utils/finalizeLogin.ts
+++ b/src/utils/finalizeLogin.ts
@@ -9,17 +9,15 @@ import type { QueryClient } from '@tanstack/react-query';
  * - 유저 정보 조회 및 캐시 저장
  *
  * @param accessToken - 액세스 토큰
- * @param refreshToken - 리프레시 토큰
  * @param queryClient - React Query 클라이언트
  * @throws 유저 정보 조회 실패 시 에러 발생
  */
 export const finalizeLogin = async (
   accessToken: string,
-  refreshToken: string,
   queryClient: QueryClient
 ): Promise<void> => {
-  // 1. 토큰 저장
-  setAuthTokens({ accessToken, refreshToken });
+  // 1. 토큰 저장 (refreshToken은 httpOnly 쿠키로 관리)
+  setAuthTokens({ accessToken });
 
   // 2. 유저 정보 조회 및 캐시 저장
   const userProfile = await getUserProfile();

--- a/src/utils/finalizeLogin.ts
+++ b/src/utils/finalizeLogin.ts
@@ -1,4 +1,4 @@
-import { setAuthTokens } from '@/utils/authStorage';
+import { setAccessToken } from '@/utils/authStorage';
 import { getUserProfile } from '@/apis/mypage/getUserProfile';
 import { queryKey } from '@/constants/queryKey';
 import type { QueryClient } from '@tanstack/react-query';
@@ -17,7 +17,7 @@ export const finalizeLogin = async (
   queryClient: QueryClient
 ): Promise<void> => {
   // 1. 토큰 저장 (refreshToken은 httpOnly 쿠키로 관리)
-  setAuthTokens({ accessToken });
+  setAccessToken(accessToken);
 
   // 2. 유저 정보 조회 및 캐시 저장
   const userProfile = await getUserProfile();

--- a/src/utils/finalizeLogout.ts
+++ b/src/utils/finalizeLogout.ts
@@ -1,4 +1,4 @@
-import { clearAuthTokens } from '@/utils/authStorage';
+import { clearAccessToken } from '@/utils/authStorage';
 import type { QueryClient } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
 import { clearRecentlyViewedDevices } from '@/utils/recentlyViewedStorage';
@@ -13,7 +13,7 @@ import { clearRecentlyViewedDevices } from '@/utils/recentlyViewedStorage';
 
 export const finalizeLogout = (queryClient: QueryClient): void => {
   // 1. 토큰 제거
-  clearAuthTokens();
+  clearAccessToken();
 
   // 2. 유저별 데이터 캐시 삭제
   queryClient.removeQueries({ queryKey: [queryKey.COMBOS] });


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #134 

## 🔍 구현한 내용
**Google OAuth 로그인 기능을 구현하고, refreshToken을 httpOnly 쿠키로 관리하도록 인증 시스템을 전면 개선했습니다.**

### 1. Google OAuth 로그인 구현
- **Google 로그인 버튼 컴포넌트** (`GoogleLoginButton.tsx`)
  - Google OAuth 인증 페이지로 리다이렉트 기능 구현

- **Google OAuth 콜백 페이지** (`GoogleCallbackPage.tsx`)
  - UI는 로딩스피너만 있도록 처리했습니다.
  - OAuth 인증 후 콜백 처리 로직 구현
  - `refreshToken` 쿠키를 사용하여  postRefresh를 통해 `accessToken` 발급
  - 로그인은 이미 백에서 완료처리 후 refreshToken을 보내기에 프론트에서의 로그인 상태 완료 처리만 진행 (`finalizeLogin` : `accessToken저장 + 유저정보 조회 및 캐시 저장`)
  - 온보딩 완료 여부에 따른 페이지 분기 처리
  - StrictMode 대응을 위한 중복 실행 방지 로직

- **라우팅 설정**
  - `/auth/callback/google` 경로 추가
  - PublicRoutes에 콜백 페이지 등록

### 2. refreshToken을 httpOnly 쿠키로 관리하도록 변경 (일반/소셜 로그인 모두 해당)

#### Axios 인스턴스 구조 개선
- **`cookieAxiosInstance` 추가** (`cookieAxios.ts`)
  - 쿠키가 필요한 API 전용 인스턴스 생성
  - `withCredentials: true` 설정으로 httpOnly 쿠키 자동 전송/수신

- **`axiosInstance` 설정 변경**
  - 기본 인스턴스는 `withCredentials: false`로 변경
  - 쿠키가 필요한 API만 `cookieAxiosInstance` 사용

#### API 함수 수정
- **`postLogin`**: `cookieAxiosInstance` 사용으로 변경
  - 일반 로그인 시에도 `refreshToken`을 httpOnly 쿠키로 수신

- **`postRefresh`**: 
  - `refreshToken` 파라미터 제거
  - `cookieAxiosInstance` 사용으로 httpOnly 쿠키 자동 전송

- **`postLogout`**:
  - `refreshToken` 헤더 제거
  - `cookieAxiosInstance` 사용으로 httpOnly 쿠키 자동 전송

#### 응답 인터셉터 개선 (`interceptors.ts`)
- `postRefresh` 함수 사용으로 변경
- `refreshToken` 확인 로직 제거 (httpOnly 쿠키로 자동 처리)
- `setAccessToken`으로 단순화

### 3. 인증 관련 함수명 및 타입 변경

#### 함수명 변경 (`authStorage.ts`)
- `setAuthTokens` → `setAccessToken`
- `clearAuthTokens` → `clearAccessToken`
- `hasAuthTokens` → `hasAccessToken`
- `getRefreshToken` 제거 (httpOnly 쿠키로 관리)

#### 타입 정의 변경
- **`LoginResult` 타입** (`types/auth/login.ts`)
  - `refreshToken: string` → `refreshToken: null` (httpOnly 쿠키로만 전송되므로 응답에서는 항상 null)

#### 관련 함수 시그니처 변경
- **`finalizeLogin`**: `refreshToken` 파라미터 제거
- **`useLogin`**: `refreshToken` 전달 로직 제거

### 🔒 보안 개선사항
- **XSS 공격 방지**: `refreshToken`을 httpOnly 쿠키로 관리하여 JavaScript 접근 차단
- **쿠키 자동 관리**: 브라우저가 자동으로 쿠키를 관리하므로 클라이언트 코드에서 명시적 처리 불필요

## 📸 스크린샷 or 실행 영상

https://github.com/user-attachments/assets/0acdab3d-9602-48f1-be6a-d05dea92ca82


## 📢 리뷰어에게
- `refreshToken`은 이제 클라이언트 코드에서 직접 접근할 수 없습니다 (httpOnly 쿠키)
- 모든 인증 관련 API는 적절한 Axios 인스턴스를 사용하도록 변경되었습니다.
- 아직 백에서 소셜로그인 쪽은 httpOnly 쿠키 방식으로 구현이 안되어서 일반로그인 쪽만 확인하실 수 있습니다.
- 리프레시 토큰을 로컬 스토리지 방식에서 쿠키방식으로 전환하면서 인스턴스명 수정,추가가 생겨 변경된 파일이 많습니다. 이부분은 너무 유심히 안보셔도 될거 같습니다.

## 🧪 테스트 시나리오
1. ✅ Google 로그인 버튼 클릭 시 OAuth 인증 페이지로 이동
2. ✅ OAuth 인증 완료 후 콜백 페이지에서 자동 로그인 처리
3. ✅ 온보딩 완료 유저는 홈으로, 미완료 유저는 온보딩 페이지로 리다이렉트
4. ✅ 일반 로그인 시에도 refreshToken이 httpOnly 쿠키로 수신되는지 확인
5. ✅ 토큰 갱신 시 refreshToken이 쿠키로 자동 전송되는지 확인
6. ✅ 로그아웃 시 쿠키가 정상적으로 삭제되는지 확인