### PR TITLE
feat: 비밀번호 수정 API 연동

### DIFF
--- a/src/apis/mypage/putEditPassword.ts
+++ b/src/apis/mypage/putEditPassword.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import { useMutation } from '@tanstack/react-query';
+import type { EditPasswordRequest, EditPasswordResponse } from '@/types/mypage/editPassword';
+
+export const putEditPassword = async (
+  payload: EditPasswordRequest
+): Promise<EditPasswordResponse> => {
+  const { data } = await axiosInstance.put<EditPasswordResponse>(
+    '/api/mypage/user-profile/password',
+    payload
+  );
+  return data;
+};
+
+export const usePutEditPassword = () => {
+  return useMutation({
+    mutationFn: putEditPassword,
+  });
+};

--- a/src/pages/my/settings/PasswordEditPage.tsx
+++ b/src/pages/my/settings/PasswordEditPage.tsx
@@ -15,57 +15,58 @@ const PasswordEditPage = () => {
   const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [isConfirmValidated, setIsConfirmValidated] = useState(false);
   const [oldPasswordServerError, setOldPasswordServerError] = useState<string>();
+  const [newPasswordServerError, setNewPasswordServerError] = useState<string>();
   const [confirmServerError, setConfirmServerError] = useState<string>();
+  const [confirmClientError, setConfirmClientError] = useState<string>();
   const newPasswordError = useMemo(() => validateNewPassword(newPassword), [newPassword]);
-
-  const confirmClientError = useMemo(() => {
-    if (!isConfirmValidated) return undefined;
-    return validatePasswordConfirm(newPassword, confirmPassword);
-  }, [isConfirmValidated, newPassword, confirmPassword]);
-
-  const hasAnyVisibleError = useMemo(() => {
-    const hasOld = !!oldPasswordServerError;
-    const hasConfirm = !!confirmServerError || !!confirmClientError;
-    const hasNew = !!newPasswordError;
-    return hasOld || hasNew || hasConfirm;
-  }, [oldPasswordServerError, confirmServerError, confirmClientError, newPasswordError]);
-
   const filled = useMemo(() => {
     return oldPassword.length > 0 && newPassword.length > 0 && confirmPassword.length > 0;
   }, [oldPassword, newPassword, confirmPassword]);
+  const hasAnyVisibleError = useMemo(() => {
+    const hasOld = !!oldPasswordServerError;
+    const hasNew = !!newPasswordError || !!newPasswordServerError;
+    const hasConfirm = !!confirmServerError || !!confirmClientError;
+    return hasOld || hasNew || hasConfirm;
+  }, [
+    oldPasswordServerError,
+    newPasswordError,
+    newPasswordServerError,
+    confirmServerError,
+    confirmClientError,
+  ]);
 
   const canSubmit = useMemo(() => {
     if (!filled) return false;
     if (newPasswordError) return false;
-    if (isConfirmValidated && (confirmClientError || confirmServerError)) return false;
     if (hasAnyVisibleError) return false;
     return true;
-  }, [
-    filled,
-    newPasswordError,
-    isConfirmValidated,
-    confirmClientError,
-    confirmServerError,
-    hasAnyVisibleError,
-  ]);
+  }, [filled, newPasswordError, hasAnyVisibleError]);
 
   const handleOldPasswordChange = (next: string) => {
     setOldPassword(next);
     if (oldPasswordServerError) setOldPasswordServerError(undefined);
   };
 
+  const handleNewPasswordChange = (next: string) => {
+    setNewPassword(next);
+    if (newPasswordServerError) setNewPasswordServerError(undefined);
+    if (confirmServerError) setConfirmServerError(undefined);
+    if (confirmClientError) setConfirmClientError(undefined);
+  };
+
   const handleConfirmChange = (next: string) => {
     setConfirmPassword(next);
     if (confirmServerError) setConfirmServerError(undefined);
+    if (confirmClientError) setConfirmClientError(undefined);
   };
 
   const handleSave = () => {
-    setIsConfirmValidated(true);
     setOldPasswordServerError(undefined);
+    setNewPasswordServerError(undefined);
     setConfirmServerError(undefined);
     const confirmErrNow = validatePasswordConfirm(newPassword, confirmPassword);
+    setConfirmClientError(confirmErrNow);
     if (newPasswordError || confirmErrNow) return;
 
     putEditPassword(
@@ -82,12 +83,17 @@ const PasswordEditPage = () => {
           const axiosError = error as AxiosError<any>;
           const code: string | undefined = axiosError.response?.data?.code;
           const message: string | undefined = axiosError.response?.data?.message;
+
           if (code === 'USER_4006') {
-            setOldPasswordServerError(message ?? '이전 비밀번호를 확인해주세요.');
+            setOldPasswordServerError(message);
             return;
           }
-          if (code === 'USER_4007' || code === 'USER_4008') {
-            setConfirmServerError(message ?? '비밀번호 확인을 다시 확인해주세요.');
+          if (code === 'USER_4007') {
+            setConfirmServerError(message);
+            return;
+          }
+          if (code === 'USER_4008') {
+            setNewPasswordServerError(message);
             return;
           }
         },
@@ -112,8 +118,8 @@ const PasswordEditPage = () => {
         />
         <NewPasswordInputSection
           value={newPassword}
-          onChange={setNewPassword}
-          errorMessage={newPasswordError}
+          onChange={handleNewPasswordChange}
+          errorMessage={newPasswordServerError ?? newPasswordError}
         />
         <PasswordConfirmInputSection
           value={confirmPassword}

--- a/src/pages/my/settings/PasswordEditPage.tsx
+++ b/src/pages/my/settings/PasswordEditPage.tsx
@@ -1,33 +1,99 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import type { AxiosError } from 'axios';
 import BackIcon from '@/assets/icons/back_gray.svg?react';
-
 import OldPasswordInputSection from '@/components/Setting/OldPasswordInputSection';
 import NewPasswordInputSection from '@/components/Setting/NewPasswordInputSection';
 import PasswordConfirmInputSection from '@/components/Setting/PasswordConfirmInputSection';
 import PrimaryButton from '@/components/Button/PrimaryButton';
-
 import { validateNewPassword, validatePasswordConfirm } from '@/utils/validatePassword';
+import { usePutEditPassword } from '@/apis/mypage/putEditPassword';
 
 const PasswordEditPage = () => {
   const navigate = useNavigate();
-
+  const { mutate: putEditPassword, isPending } = usePutEditPassword();
   const [oldPassword, setOldPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-
+  const [isConfirmValidated, setIsConfirmValidated] = useState(false);
+  const [oldPasswordServerError, setOldPasswordServerError] = useState<string>();
+  const [confirmServerError, setConfirmServerError] = useState<string>();
   const newPasswordError = useMemo(() => validateNewPassword(newPassword), [newPassword]);
-  const confirmPasswordError = useMemo(
-    () => validatePasswordConfirm(newPassword, confirmPassword),
-    [newPassword, confirmPassword]
-  );
+
+  const confirmClientError = useMemo(() => {
+    if (!isConfirmValidated) return undefined;
+    return validatePasswordConfirm(newPassword, confirmPassword);
+  }, [isConfirmValidated, newPassword, confirmPassword]);
+
+  const hasAnyVisibleError = useMemo(() => {
+    const hasOld = !!oldPasswordServerError;
+    const hasConfirm = !!confirmServerError || !!confirmClientError;
+    const hasNew = !!newPasswordError;
+    return hasOld || hasNew || hasConfirm;
+  }, [oldPasswordServerError, confirmServerError, confirmClientError, newPasswordError]);
+
+  const filled = useMemo(() => {
+    return oldPassword.length > 0 && newPassword.length > 0 && confirmPassword.length > 0;
+  }, [oldPassword, newPassword, confirmPassword]);
 
   const canSubmit = useMemo(() => {
-    const filled = oldPassword.length > 0 && newPassword.length > 0 && confirmPassword.length > 0;
     if (!filled) return false;
-    if (newPasswordError || confirmPasswordError) return false;
+    if (newPasswordError) return false;
+    if (isConfirmValidated && (confirmClientError || confirmServerError)) return false;
+    if (hasAnyVisibleError) return false;
     return true;
-  }, [oldPassword, newPassword, confirmPassword, newPasswordError, confirmPasswordError]);
+  }, [
+    filled,
+    newPasswordError,
+    isConfirmValidated,
+    confirmClientError,
+    confirmServerError,
+    hasAnyVisibleError,
+  ]);
+
+  const handleOldPasswordChange = (next: string) => {
+    setOldPassword(next);
+    if (oldPasswordServerError) setOldPasswordServerError(undefined);
+  };
+
+  const handleConfirmChange = (next: string) => {
+    setConfirmPassword(next);
+    if (confirmServerError) setConfirmServerError(undefined);
+  };
+
+  const handleSave = () => {
+    setIsConfirmValidated(true);
+    setOldPasswordServerError(undefined);
+    setConfirmServerError(undefined);
+    const confirmErrNow = validatePasswordConfirm(newPassword, confirmPassword);
+    if (newPasswordError || confirmErrNow) return;
+
+    putEditPassword(
+      {
+        oldPassword,
+        newPassword,
+        newPasswordConfirm: confirmPassword,
+      },
+      {
+        onSuccess: () => {
+          navigate('/my');
+        },
+        onError: (error) => {
+          const axiosError = error as AxiosError<any>;
+          const code: string | undefined = axiosError.response?.data?.code;
+          const message: string | undefined = axiosError.response?.data?.message;
+          if (code === 'USER_4006') {
+            setOldPasswordServerError(message ?? '이전 비밀번호를 확인해주세요.');
+            return;
+          }
+          if (code === 'USER_4007' || code === 'USER_4008') {
+            setConfirmServerError(message ?? '비밀번호 확인을 다시 확인해주세요.');
+            return;
+          }
+        },
+      }
+    );
+  };
 
   return (
     <div className="flex flex-col gap-72 mx-auto w-560 mt-92 mb-92">
@@ -39,7 +105,11 @@ const PasswordEditPage = () => {
         <p className="font-heading-2 text-black">비밀번호 수정</p>
       </div>
       <div className="flex flex-col gap-20 w-560">
-        <OldPasswordInputSection value={oldPassword} onChange={setOldPassword} />
+        <OldPasswordInputSection
+          value={oldPassword}
+          onChange={handleOldPasswordChange}
+          errorMessage={oldPasswordServerError}
+        />
         <NewPasswordInputSection
           value={newPassword}
           onChange={setNewPassword}
@@ -47,15 +117,16 @@ const PasswordEditPage = () => {
         />
         <PasswordConfirmInputSection
           value={confirmPassword}
-          onChange={setConfirmPassword}
-          errorMessage={confirmPasswordError}
+          onChange={handleConfirmChange}
+          errorMessage={confirmServerError ?? confirmClientError}
         />
       </div>
       <div className="flex justify-center">
         <PrimaryButton
           className="w-400 bg-blue-600 hover:bg-blue-500 disabled:hover:bg-gray-300"
-          text="저장하기"
-          disabled={!canSubmit}
+          text={isPending ? '저장 중...' : '저장하기'}
+          onClick={handleSave}
+          disabled={!canSubmit || isPending}
         />
       </div>
     </div>

--- a/src/pages/my/settings/ProfileEditPage.tsx
+++ b/src/pages/my/settings/ProfileEditPage.tsx
@@ -55,6 +55,7 @@ const ProfileEditPage = () => {
       {
         onSuccess: async () => {
           await refetchUserProfile();
+          navigate('/my');
         },
       }
     );

--- a/src/types/mypage/editPassword.ts
+++ b/src/types/mypage/editPassword.ts
@@ -1,0 +1,11 @@
+import type { CommonResponse } from '../common';
+
+// 비밀번호 수정 request
+export type EditPasswordRequest = {
+  oldPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
+// 비밀번호 수정 response
+export type EditPasswordResponse = CommonResponse<null>;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #135

## 🔍 구현한 내용 
- **비밀번호 수정 API 연동**
- **비밀번호 수정 페이지 에러 처리/노출 로직 개선**

  - 서버 에러 코드를 필드별로 매핑해서 각기 다른 위치에 다른 문구가 뜨도록 처리
  
    - 이전 비밀번호 불일치(USER_4006) → 기존 비밀번호 영역에 노출
    - 새 비밀번호/확인 불일치(USER_4007) → 비밀번호 확인 영역에 노출
    - 이전 비밀번호와 새 비밀번호 동일(USER_4008) → 새 비밀번호 영역에 노출
  - 클라이언트 검증(새 비밀번호 조건/확인 일치) + 서버 에러를 함께 고려해 canSubmit 계산
  - 입력 변경 시 기존 에러 상태를 적절히 초기화하도록 핸들러 분리
  - 요청 중에는 버튼 isPending 반영 + disabled 처리

- **프로필 수정 & 비밀번호 수정 성공 후 처리 보완**
  - 두 페이지 모두 수정 성공 시 /my로 이동하도록 했습니다.


## 📸 스크린샷 or 실행 영상
케이스에 따라 각기 다른 위치에 다른 에러 문구가 노출됩니다.
  - 이전 비밀번호 일치하지 않을 시 -> 기존 비밀번호가 일치하지 않습니다.
  - 새 비밀번호, 비밀번호 확인 일치하지 않을 시 -> 새 비밀번호가 일치하지 않습니다.
  - 이전 비밀번호와 새 비밀번호가 같을 시 -> 새 비밀번호는 기존 비밀번호와 다르게 설정해주세요.

https://github.com/user-attachments/assets/931b86a6-3cce-4101-b38d-0aeeaf5d671b



## 📢 리뷰어에게
