### PR TITLE
feat: 최근에 본 기기 API 연동

### DIFF
--- a/src/apis/recentlyViewed/getRecentlyViewed.ts
+++ b/src/apis/recentlyViewed/getRecentlyViewed.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import { useQuery } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+import type { RecentlyViewedDevicesResponse, RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
+
+// 최근 본 기기 목록 조회 API
+export const getRecentlyViewed = async (): Promise<RecentlyViewedDevice[]> => {
+  const { data } = await axiosInstance.get<RecentlyViewedDevicesResponse>('/api/recently-viewed');
+  return data.result ?? [];
+};
+
+// 최근 본 기기 목록 조회 Query
+export const useGetRecentlyViewed = () => {
+  return useQuery<RecentlyViewedDevice[]>({
+    queryKey: [queryKey.RECENTLY_VIEWED_DEVICES],
+    queryFn: getRecentlyViewed,
+    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
+  });
+};

--- a/src/apis/recentlyViewed/getRecentlyViewed.ts
+++ b/src/apis/recentlyViewed/getRecentlyViewed.ts
@@ -12,7 +12,7 @@ export const getRecentlyViewed = async (): Promise<RecentlyViewedDevice[]> => {
 // 최근 본 기기 목록 조회 Query
 export const useGetRecentlyViewed = () => {
   return useQuery<RecentlyViewedDevice[]>({
-    queryKey: [queryKey.RECENTLY_VIEWED_DEVICES],
+    queryKey: [queryKey.RECENTLY_VIEWED],
     queryFn: getRecentlyViewed,
     staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
   });

--- a/src/apis/recentlyViewed/getRecentlyViewed.ts
+++ b/src/apis/recentlyViewed/getRecentlyViewed.ts
@@ -14,6 +14,6 @@ export const useGetRecentlyViewed = () => {
   return useQuery<RecentlyViewedDevice[]>({
     queryKey: [queryKey.RECENTLY_VIEWED],
     queryFn: getRecentlyViewed,
-    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
+    staleTime: 1000 * 30, // 30초간 캐시 유지
   });
 };

--- a/src/apis/recentlyViewed/getRecentlyViewed.ts
+++ b/src/apis/recentlyViewed/getRecentlyViewed.ts
@@ -12,7 +12,7 @@ export const getRecentlyViewed = async (): Promise<RecentlyViewedDevice[]> => {
 // 최근 본 기기 목록 조회 Query
 export const useGetRecentlyViewed = () => {
   return useQuery<RecentlyViewedDevice[]>({
-    queryKey: [queryKey.RECENTLY_VIEWED],
+    queryKey: [queryKey.RECENTLY_VIEWED_DEVICES],
     queryFn: getRecentlyViewed,
     staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
   });

--- a/src/components/RecentlyViewed/RecentlyViewedCard.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedCard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
 
 interface RecentlyViewedCardProps {
   device: RecentlyViewedDevice;
@@ -15,9 +15,9 @@ const RecentlyViewedCard = ({ device, onClick, className }: RecentlyViewedCardPr
     >
       {/* 이미지 - 149x149 */}
       <div className="w-149 h-149 bg-gray-200 overflow-hidden">
-        {device.image && (
+        {device.imageUrl && (
           <img
-            src={device.image}
+            src={device.imageUrl}
             alt={device.name}
             className="w-full h-full object-cover"
           />
@@ -30,16 +30,16 @@ const RecentlyViewedCard = ({ device, onClick, className }: RecentlyViewedCardPr
         <p className="font-body-2-r text-black leading-22 truncate group-hover:text-blue-600 transition-colors">{device.name}</p>
 
         {/* 카테고리 - 12px, SemiBold, Gray300 */}
-        <p className="font-caption-sm text-gray-300">{device.category}</p>
+        <p className="font-caption-sm text-gray-300">{device.deviceType}</p>
 
         {/* 가격 - 16px, SemiBold */}
         <p className="font-body-2-sm text-black mt-8">
-          {device.price != null
+          {device.priceKrw != null
             ? new Intl.NumberFormat('ko-KR', {
                 style: 'currency',
                 currency: 'KRW',
                 maximumFractionDigits: 0,
-              }).format(device.price)
+              }).format(device.priceKrw)
             : '-'}
         </p>
       </div>

--- a/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
+import { useGetRecentlyViewed } from '@/apis/recentlyViewed/getRecentlyViewed';
 import RecentlyViewedCard from './RecentlyViewedCard';
 
 interface RecentlyViewedFloatingProps {
@@ -13,7 +13,7 @@ const RecentlyViewedFloating = ({
   sidebarContentRef,
 }: RecentlyViewedFloatingProps) => {
   const navigate = useNavigate();
-  const { devices } = useRecentlyViewed();
+  const { data: devices = [], isLoading } = useGetRecentlyViewed();
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFloating, setIsFloating] = useState(false);
   const [leftPosition, setLeftPosition] = useState(0);
@@ -58,8 +58,8 @@ const RecentlyViewedFloating = ({
     };
   }, [sidebarContentRef]);
 
-  // 기기가 없으면 렌더링하지 않음
-  if (displayDevices.length === 0) return null;
+  // 로딩 중이거나 기기가 없으면 렌더링하지 않음
+  if (isLoading || displayDevices.length === 0) return null;
 
   const handleCardClick = (deviceId: number) => {
     navigate(`/devices?productId=${deviceId}`);

--- a/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
+++ b/src/components/RecentlyViewed/RecentlyViewedFloating.tsx
@@ -90,9 +90,9 @@ const RecentlyViewedFloating = ({
       <div className="flex flex-col gap-28">
         {displayDevices.map((device) => (
           <RecentlyViewedCard
-            key={device.id}
+            key={device.deviceId}
             device={device}
-            onClick={() => handleCardClick(device.id)}
+            onClick={() => handleCardClick(device.deviceId)}
           />
         ))}
       </div>

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -8,5 +8,6 @@ export const queryKey = {
   COMBOS: 'combos',
   COMBO_DETAIL: 'combo',
   LIFESTYLE_DEVICE: 'lifestyle_device',
-  BRANDS: 'brands'
+  BRANDS: 'brands',
+  RECENTLY_VIEWED: 'recently_viewed',
 } as const;

--- a/src/hooks/useRecentlyViewed.ts
+++ b/src/hooks/useRecentlyViewed.ts
@@ -1,41 +1,41 @@
-import { useState, useEffect, useCallback } from 'react';
-import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
-import {
-  getRecentlyViewedDevices,
-  addRecentlyViewedDevice,
-  removeRecentlyViewedDevice,
-} from '@/utils/recentlyViewedStorage';
-import { MOCK_RECENTLY_VIEWED_DEVICES } from '@/constants/mockData';
+// import { useState, useEffect, useCallback } from 'react';
+// import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+// import {
+//   getRecentlyViewedDevices,
+//   addRecentlyViewedDevice,
+//   removeRecentlyViewedDevice,
+// } from '@/utils/recentlyViewedStorage';
+// import { MOCK_RECENTLY_VIEWED_DEVICES } from '@/constants/mockData';
 
-export const useRecentlyViewed = () => {
-  const [devices, setDevices] = useState<RecentlyViewedDevice[]>([]);
+// export const useRecentlyViewed = () => {
+//   const [devices, setDevices] = useState<RecentlyViewedDevice[]>([]);
 
-  // 초기 로드 (localStorage가 비어있으면 mockdata 사용)
-  useEffect(() => {
-    const storedDevices = getRecentlyViewedDevices();
-    if (storedDevices.length > 0) {
-      setDevices(storedDevices);
-    } else {
-      setDevices(MOCK_RECENTLY_VIEWED_DEVICES);
-    }
-  }, []);
+//   // 초기 로드 (localStorage가 비어있으면 mockdata 사용)
+//   useEffect(() => {
+//     const storedDevices = getRecentlyViewedDevices();
+//     if (storedDevices.length > 0) {
+//       setDevices(storedDevices);
+//     } else {
+//       setDevices(MOCK_RECENTLY_VIEWED_DEVICES);
+//     }
+//   }, []);
 
-  // 기기 추가
-  const addDevice = useCallback((device: Omit<RecentlyViewedDevice, 'viewedAt'>) => {
-    addRecentlyViewedDevice(device);
-    setDevices(getRecentlyViewedDevices());
-  }, []);
+//   // 기기 추가
+//   const addDevice = useCallback((device: Omit<RecentlyViewedDevice, 'viewedAt'>) => {
+//     addRecentlyViewedDevice(device);
+//     setDevices(getRecentlyViewedDevices());
+//   }, []);
 
-  // 기기 제거
-  const removeDevice = useCallback((deviceId: number) => {
-    removeRecentlyViewedDevice(deviceId);
-    setDevices(getRecentlyViewedDevices());
-  }, []);
+//   // 기기 제거
+//   const removeDevice = useCallback((deviceId: number) => {
+//     removeRecentlyViewedDevice(deviceId);
+//     setDevices(getRecentlyViewedDevices());
+//   }, []);
 
-  return {
-    devices,
-    addDevice,
-    removeDevice,
-    hasDevices: devices.length > 0,
-  };
-};
+//   return {
+//     devices,
+//     addDevice,
+//     removeDevice,
+//     hasDevices: devices.length > 0,
+//   };
+// };

--- a/src/pages/onboarding/OnboardingRecommendationPage.tsx
+++ b/src/pages/onboarding/OnboardingRecommendationPage.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import PrimaryButton from '@/components/Button/PrimaryButton';
 import RecentlyViewedCard from '@/components/RecentlyViewed/RecentlyViewedCard';
 import LoadingSpinner from '@/components/LoadingSpinner';
-import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
 import type { LifestyleTagKey } from '@/types/lifestyle/lifestyle';
 import { useAuth } from '@/hooks/useAuth';
 import { useGroupedTags } from '@/hooks/useGroupedTags';
@@ -56,12 +56,16 @@ const OnboardingRecommendationPage = () => {
   const recommendedDevices: RecentlyViewedDevice[] = (lifestyleData?.result?.devices ?? [])
     .slice(0, 3)
     .map((device) => ({
-      id: device.deviceId,
+      deviceId: device.deviceId,
       name: device.displayName,
-      category: '',
+      modelCode: '',
+      brandName: '',
+      deviceType: '',
       price: device.price,
-      image: device.imageUrl,
-      viewedAt: Date.now(),
+      priceCurrency: device.currency,
+      priceKrw: device.price,
+      imageUrl: device.imageUrl,
+      viewedAt: new Date().toISOString(),
     }));
 
   // 내 조합에 담기 핸들러
@@ -117,16 +121,16 @@ const OnboardingRecommendationPage = () => {
               <LoadingSpinner />
             ) : recommendedDevices.length > 0 ? (
               recommendedDevices.map((device) => {
-                const isSelected = selectedDeviceId === device.id;
+                const isSelected = selectedDeviceId === device.deviceId;
                 return (
                   <RecentlyViewedCard
-                    key={device.id}
+                    key={device.deviceId}
                     device={device}
                     className={clsx(
                       'rounded-8 transition-all',
                       isSelected && 'border-shadow-blue'
                     )}
-                    onClick={() => selectDevice(device.id)}
+                    onClick={() => selectDevice(device.deviceId)}
                   />
                 );
               })

--- a/src/types/recentlyViewed.ts
+++ b/src/types/recentlyViewed.ts
@@ -1,9 +1,0 @@
-// 최근 본 기기 데이터 타입
-export interface RecentlyViewedDevice {
-  id: number;
-  name: string;
-  category: string;
-  price: number;
-  image: string | null;
-  viewedAt: number;
-}

--- a/src/types/recentlyViewed/recentlyViewed.ts
+++ b/src/types/recentlyViewed/recentlyViewed.ts
@@ -1,15 +1,18 @@
 import type { CommonResponse } from '@/types/common';
 
-// 최근 본 기기 데이터 타입 (UI 표시용)
+// 최근 본 기기 데이터 타입 (API 응답 형식)
 export interface RecentlyViewedDevice {
-  id: number;
+  deviceId: number;
   name: string;
-  category: string;
+  modelCode: string;
+  brandName: string;
+  deviceType: string;
   price: number;
-  image: string | null;
-  viewedAt: number;
+  priceCurrency: string;
+  priceKrw: number;
+  imageUrl: string;
+  viewedAt: string; // ISO date string
 }
 
 // 최근 본 기기 목록 조회 응답 타입 (API 응답)
-// API 문서상 string[]이지만, 실제로는 기기 정보 객체 배열일 수 있음
 export type RecentlyViewedDevicesResponse = CommonResponse<RecentlyViewedDevice[]>;

--- a/src/types/recentlyViewed/recentlyViewed.ts
+++ b/src/types/recentlyViewed/recentlyViewed.ts
@@ -1,0 +1,15 @@
+import type { CommonResponse } from '@/types/common';
+
+// 최근 본 기기 데이터 타입 (UI 표시용)
+export interface RecentlyViewedDevice {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  image: string | null;
+  viewedAt: number;
+}
+
+// 최근 본 기기 목록 조회 응답 타입 (API 응답)
+// API 문서상 string[]이지만, 실제로는 기기 정보 객체 배열일 수 있음
+export type RecentlyViewedDevicesResponse = CommonResponse<RecentlyViewedDevice[]>;

--- a/src/utils/finalizeLogout.ts
+++ b/src/utils/finalizeLogout.ts
@@ -1,14 +1,12 @@
 import { clearAccessToken } from '@/utils/authStorage';
 import type { QueryClient } from '@tanstack/react-query';
 import { queryKey } from '@/constants/queryKey';
-import { clearRecentlyViewedDevices } from '@/utils/recentlyViewedStorage';
 
 /*
 로그아웃 처리 함수
 
 1. 토큰 제거
 2. 유저별 데이터 캐시 삭제 (조합 목록, 조합 상세, 유저 정보)
-3. 최근 본 기기 목록 삭제 (유저별 데이터)
 */
 
 export const finalizeLogout = (queryClient: QueryClient): void => {
@@ -19,7 +17,4 @@ export const finalizeLogout = (queryClient: QueryClient): void => {
   queryClient.removeQueries({ queryKey: [queryKey.COMBOS] });
   queryClient.removeQueries({ queryKey: [queryKey.COMBO_DETAIL] });
   queryClient.removeQueries({ queryKey: [queryKey.USER_PROFILE] });
-
-  // 3. 최근 본 기기 목록 삭제 (유저별 데이터)
-  clearRecentlyViewedDevices();
 };

--- a/src/utils/recentlyViewedStorage.ts
+++ b/src/utils/recentlyViewedStorage.ts
@@ -1,53 +1,53 @@
-import { RECENTLY_VIEWED_DEVICES, RECENTLY_VIEWED_MAX_COUNT } from '@/constants/storageKeys';
-import type { RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
+// import { RECENTLY_VIEWED_DEVICES, RECENTLY_VIEWED_MAX_COUNT } from '@/constants/storageKeys';
+// import type { RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
 
-// localStorage를 조작하는 유틸리티 함수
-// 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함
+// // localStorage를 조작하는 유틸리티 함수
+// // 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함
 
-// 최근 본 기기 목록 가져오기
-export const getRecentlyViewedDevices = (): RecentlyViewedDevice[] => {
-  try {
-    const data = localStorage.getItem(RECENTLY_VIEWED_DEVICES);
-    if (!data) return [];
-    return JSON.parse(data) as RecentlyViewedDevice[];
-  } catch {
-    return [];
-  }
-};
+// // 최근 본 기기 목록 가져오기
+// export const getRecentlyViewedDevices = (): RecentlyViewedDevice[] => {
+//   try {
+//     const data = localStorage.getItem(RECENTLY_VIEWED_DEVICES);
+//     if (!data) return [];
+//     return JSON.parse(data) as RecentlyViewedDevice[];
+//   } catch {
+//     return [];
+//   }
+// };
 
-// 기기 추가 (가장 최근 것이 맨 앞, 중복 제거, 최대 개수 제한)
-export const addRecentlyViewedDevice = (
-  device: Omit<RecentlyViewedDevice, 'viewedAt'>
-): void => {
-  const devices = getRecentlyViewedDevices();
+// // 기기 추가 (가장 최근 것이 맨 앞, 중복 제거, 최대 개수 제한)
+// export const addRecentlyViewedDevice = (
+//   device: Omit<RecentlyViewedDevice, 'viewedAt'>
+// ): void => {
+//   const devices = getRecentlyViewedDevices();
 
-  // 이미 있는 기기는 제거 (중복 방지)
-  const filteredDevices = devices.filter((d) => d.id !== device.id);
+//   // 이미 있는 기기는 제거 (중복 방지)
+//   const filteredDevices = devices.filter((d) => d.id !== device.id);
 
-  // 새 기기를 맨 앞에 추가
-  const newDevice: RecentlyViewedDevice = {
-    ...device,
-    viewedAt: Date.now(),
-  };
+//   // 새 기기를 맨 앞에 추가
+//   const newDevice: RecentlyViewedDevice = {
+//     ...device,
+//     viewedAt: Date.now(),
+//   };
 
-  const updatedDevices = [newDevice, ...filteredDevices].slice(0, RECENTLY_VIEWED_MAX_COUNT);
+//   const updatedDevices = [newDevice, ...filteredDevices].slice(0, RECENTLY_VIEWED_MAX_COUNT);
 
-  localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(updatedDevices));
-};
+//   localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(updatedDevices));
+// };
 
-// 특정 기기 삭제
-export const removeRecentlyViewedDevice = (deviceId: number): void => {
-  const devices = getRecentlyViewedDevices();
-  const filteredDevices = devices.filter((d) => d.id !== deviceId);
-  localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(filteredDevices));
-};
+// // 특정 기기 삭제
+// export const removeRecentlyViewedDevice = (deviceId: number): void => {
+//   const devices = getRecentlyViewedDevices();
+//   const filteredDevices = devices.filter((d) => d.id !== deviceId);
+//   localStorage.setItem(RECENTLY_VIEWED_DEVICES, JSON.stringify(filteredDevices));
+// };
 
-// 전체 삭제
-export const clearRecentlyViewedDevices = (): void => {
-  localStorage.removeItem(RECENTLY_VIEWED_DEVICES);
-};
+// // 전체 삭제
+// export const clearRecentlyViewedDevices = (): void => {
+//   localStorage.removeItem(RECENTLY_VIEWED_DEVICES);
+// };
 
-// 최근 본 기기 존재 여부
-export const hasRecentlyViewedDevices = (): boolean => {
-  return getRecentlyViewedDevices().length > 0;
-};
+// // 최근 본 기기 존재 여부
+// export const hasRecentlyViewedDevices = (): boolean => {
+//   return getRecentlyViewedDevices().length > 0;
+// };

--- a/src/utils/recentlyViewedStorage.ts
+++ b/src/utils/recentlyViewedStorage.ts
@@ -1,5 +1,5 @@
 import { RECENTLY_VIEWED_DEVICES, RECENTLY_VIEWED_MAX_COUNT } from '@/constants/storageKeys';
-import type { RecentlyViewedDevice } from '@/types/recentlyViewed';
+import type { RecentlyViewedDevice } from '@/types/recentlyViewed/recentlyViewed';
 
 // localStorage를 조작하는 유틸리티 함수
 // 나머지 파일에서는 localStorage를 직접 사용하지 않고 이 파일의 함수를 사용하도록 함


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #137 

## 🔍 구현한 내용
### 1. API 함수 추가
- **파일**: `src/apis/recentlyViewed/getRecentlyViewed.ts`
- `GET /api/recently-viewed` 엔드포인트 연동
- React Query를 사용한 데이터 페칭 및 캐싱 (30초 staleTime)
- `useGetRecentlyViewed` 훅 제공

### 2. 타입 정의 변경
- **파일**: `src/types/recentlyViewed/recentlyViewed.ts` (신규)
- **삭제**: `src/types/recentlyViewed.ts` (기존 로컬 스토리지용 타입)
- API 응답 형식에 맞춘 `RecentlyViewedDevice` 인터페이스 정의
  - `deviceId`, `name`, `modelCode`, `brandName`, `deviceType`
  - `price`, `priceCurrency`, `priceKrw`
  - `imageUrl`, `viewedAt` (ISO date string)

### 3. 컴포넌트 수정
- **RecentlyViewedFloating.tsx**
  - 로컬 스토리지 훅(`useRecentlyViewed`) 제거
  - API 훅(`useGetRecentlyViewed`) 직접 사용
  - 로딩 상태 처리 추가 (`isLoading`)
  
- **RecentlyViewedCard.tsx**
  - 필드명 변경: `image` → `imageUrl`
  - 필드명 변경: `category` → `deviceType`
  - 필드명 변경: `price` → `priceKrw`
  - 필드명 변경: `id` → `deviceId`

### 4. 상수 추가
- **queryKey.ts**: `RECENTLY_VIEWED: 'recently_viewed'` 추가
## 📸 스크린샷 or 실행 영상
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/277cbea8-7dd6-4afd-9f7e-ff40c1b69b79" />

## 📢 리뷰어에게
- 병훈님이 아마도 목데이터를 띄우기 위해 구현하신 hooks/useRecentlyViewed와 utils/recentlyViewedStorage는 로컬스토리지 기반이라 안쓰이나 혹시 몰라 주석 처리해놨습니다. 
- 기기검색 창에서 api연동이 완료되면 백에서 응답값이 정상적으로 내려올거 같습니다. 지금은 빈배열로 오기에 렌더링이 안됩니다.