### PR TITLE
feat: 기기 검색 API 구현

### DIFF
--- a/src/apis/devices/searchDevices.ts
+++ b/src/apis/devices/searchDevices.ts
@@ -1,0 +1,34 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import type {
+  SearchDevicesParams,
+  GetDevicesSearchResponse,
+  DeviceSearchResult,
+} from '@/types/devices';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+
+export const searchDevices = async (
+  params: SearchDevicesParams
+): Promise<DeviceSearchResult> => {
+  const { data } = await axiosInstance.get<GetDevicesSearchResponse>(
+    '/api/devices/search',
+    { params }
+  );
+  return data.result ?? { devices: [], nextCursor: null, hasNext: false };
+};
+
+export const useSearchDevices = (params: Omit<SearchDevicesParams, 'cursor'>) => {
+  return useInfiniteQuery<DeviceSearchResult, Error>({
+    queryKey: [queryKey.DEVICE_SEARCH, params],
+    queryFn: ({ pageParam }) =>
+      searchDevices({
+        ...params,
+        cursor: pageParam as string | undefined,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage?.hasNext ? lastPage.nextCursor : undefined,
+    enabled: true,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -12,7 +12,15 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
       onClick={onClick}
     >
       {/* Image - 정사각형 */}
-      <div className="w-full aspect-square bg-gray-200 mb-20" />
+      <div className="w-full aspect-square bg-gray-200 mb-20 overflow-hidden relative">
+        {product.image ? (
+          <img
+            src={product.image}
+            alt={product.name}
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        ) : null}
+      </div>
 
       {/* Content */}
       <div className="flex flex-col gap-16">

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -19,7 +19,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
         {/* Name & Category */}
         <div className="flex flex-col gap-4">
           <p className="font-heading-4 text-black group-hover:text-blue-600 transition-colors">
-            {product.name.length > 24 ? `${product.name.slice(0, 24)}...` : product.name}
+            {product.name.length > 21 ? `${product.name.slice(0, 21)}...` : product.name}
           </p>
           <p className="font-body-2-sm text-gray-300">{product.category}</p>
         </div>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -18,13 +18,15 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
       <div className="flex flex-col gap-16">
         {/* Name & Category */}
         <div className="flex flex-col gap-4">
-          <p className="font-heading-4 text-black group-hover:text-blue-600 transition-colors">{product.name}</p>
+          <p className="font-heading-4 text-black group-hover:text-blue-600 transition-colors">
+            {product.name.length > 24 ? `${product.name.slice(0, 24)}...` : product.name}
+          </p>
           <p className="font-body-2-sm text-gray-300">{product.category}</p>
         </div>
 
         {/* Price */}
         <p className="font-body-1-sm text-gray-500">
-          {product.price.toLocaleString()}
+          {(product.price ?? 0).toLocaleString()}
         </p>
 
         {/* Color Chips */}

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -27,7 +27,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onClick }) => {
         {/* Name & Category */}
         <div className="flex flex-col gap-4">
           <p className="font-heading-4 text-black group-hover:text-blue-600 transition-colors">
-            {product.name.length > 21 ? `${product.name.slice(0, 21)}...` : product.name}
+            {product.name.length > 19 ? `${product.name.slice(0, 19)}...` : product.name}
           </p>
           <p className="font-body-2-sm text-gray-300">{product.category}</p>
         </div>

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -10,4 +10,5 @@ export const queryKey = {
   LIFESTYLE_DEVICE: 'lifestyle_device',
   BRANDS: 'brands',
   RECENTLY_VIEWED: 'recently_viewed',
+  DEVICE_SEARCH: 'device_search',
 } as const;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface UseIntersectionObserverOptions {
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+}
+
+export const useIntersectionObserver = (
+  options: UseIntersectionObserverOptions = {}
+) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsIntersecting(entry.isIntersecting);
+      },
+      {
+        root: options.root ?? null,
+        rootMargin: options.rootMargin ?? '0px',
+        threshold: options.threshold ?? 0,
+      }
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [options.root, options.rootMargin, options.threshold]);
+
+  return { targetRef, isIntersecting };
+};

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -61,14 +61,24 @@ const getSortType = (sortOption: string) => {
 };
 
 // SearchDevice를 Product 형식으로 변환
-const mapSearchDeviceToProduct = (device: SearchDevice) => ({
-  id: device.deviceId,
-  name: `${device.brandName ?? ''} ${device.name ?? ''}`.trim(),
-  category: device.deviceType ?? '',
-  price: device.price ?? 0,
-  image: device.imageUrl ?? null,
-  colors: [] as string[],
-});
+const mapSearchDeviceToProduct = (device: SearchDevice) => {
+  const brandName = device.brandName ?? '';
+  const deviceName = device.name ?? '';
+
+  // device.name이 이미 brandName으로 시작하면 중복 방지
+  const fullName = deviceName.startsWith(brandName)
+    ? deviceName
+    : `${brandName} ${deviceName}`.trim();
+
+  return {
+    id: device.deviceId,
+    name: fullName,
+    category: device.deviceType ?? '',
+    price: device.price ?? 0,
+    image: device.imageUrl ?? null,
+    colors: [] as string[],
+  };
+};
 
 const DeviceSearchPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -7,6 +7,7 @@ import CombinationDeviceCard from '@/components/Combination/CombinationDeviceCar
 import ProductLife from '@/components/ProductCard/ProductLife';
 import FilterDropdown from '@/components/Filter/FilterDropdown';
 import SortDropdown from '@/components/Filter/SortDropdown';
+import LoadingSpinner from '@/components/LoadingSpinner';
 import SearchIcon from '@/assets/icons/search.svg?react';
 import FilterIcon from '@/assets/icons/filter.svg?react';
 import TopIcon from '@/assets/icons/top.svg?react';
@@ -458,11 +459,9 @@ const DeviceSearchPage = () => {
 
         {/* Product Grid */}
         <div ref={productGridRef} className="mx-auto px-120 2xl:px-160">
-          {/* 초기 로딩: 데이터가 없고 로딩 중일 때만 로딩 메시지 표시 */}
+          {/* 초기 로딩: 데이터가 없고 로딩 중일 때만 로딩 스피너 표시 */}
           {isSearchLoading && allDevices.length === 0 ? (
-            <div className="flex justify-center items-center py-100">
-              <p className="font-body-1-r text-gray-400">로딩 중...</p>
-            </div>
+            <LoadingSpinner />
           ) : isSearchError && allDevices.length === 0 ? (
             <div className="flex justify-center items-center py-100">
               <p className="font-body-1-r text-red-500">검색 결과를 불러오는데 실패했습니다.</p>
@@ -492,7 +491,7 @@ const DeviceSearchPage = () => {
           {/* 로딩 인디케이터 */}
           {isFetchingNextPage && (
             <div className="flex justify-center py-40">
-              <p className="font-body-1-r text-gray-400">더 불러오는 중...</p>
+              <LoadingSpinner />
             </div>
           )}
         </div>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -561,6 +561,13 @@ const DeviceSearchPage = () => {
                     <div className="flex items-start gap-56">
                       {/* Image */}
                       <div className="w-400 h-400 bg-gray-200 relative">
+                        {selectedProduct.image ? (
+                          <img
+                            src={selectedProduct.image}
+                            alt={selectedProduct.name}
+                            className="absolute inset-0 w-full h-full object-contain"
+                          />
+                        ) : null}
                       </div>
 
                       {/* Right Section - Specs */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -448,11 +448,12 @@ const DeviceSearchPage = () => {
 
         {/* Product Grid */}
         <div ref={productGridRef} className="mx-auto px-120 2xl:px-160">
-          {isSearchLoading ? (
+          {/* 초기 로딩: 데이터가 없고 로딩 중일 때만 로딩 메시지 표시 */}
+          {isSearchLoading && allDevices.length === 0 ? (
             <div className="flex justify-center items-center py-100">
               <p className="font-body-1-r text-gray-400">로딩 중...</p>
             </div>
-          ) : isSearchError ? (
+          ) : isSearchError && allDevices.length === 0 ? (
             <div className="flex justify-center items-center py-100">
               <p className="font-body-1-r text-red-500">검색 결과를 불러오는데 실패했습니다.</p>
             </div>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -222,10 +222,10 @@ const DeviceSearchPage = () => {
           setShowSaveCompleteModal(false);
           setIsFadingOut(false);
           handleCloseModal();
-        }, 200); // 0.2초
+        }, 200);
 
         return () => clearTimeout(closeTimer);
-      }, 800); // 0.8초
+      }, 800);
 
       return () => clearTimeout(holdTimer);
     }

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -358,7 +358,7 @@ const DeviceSearchPage = () => {
   };
 
   return (
-    <div className={`min-h-screen bg-white relative ${isAtBottom ? 'bg-effect-fade-bottom' : ''}`}>
+    <div className={`min-h-screen bg-white relative max-w-[100vw] overflow-x-hidden ${isAtBottom ? 'bg-effect-fade-bottom' : ''}`}>
       <GNB />
 
       {/* Main Content */}

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -491,7 +491,7 @@ const DeviceSearchPage = () => {
           {/* 로딩 인디케이터 */}
           {isFetchingNextPage && (
             <div className="flex justify-center py-40">
-              <LoadingSpinner />
+              <p className="font-body-1-r text-gray-400">더 불러오는 중...</p>
             </div>
           )}
         </div>
@@ -580,10 +580,6 @@ const DeviceSearchPage = () => {
                             <p className="font-body-2-r text-black">{selectedDevice?.brandName ?? '-'}</p>
                           </div>
                           <div className="flex items-center gap-24">
-                            <p className="font-body-2-r text-gray-400 w-80">색상</p>
-                            <p className="font-body-2-r text-black">내추럴 티타늄</p>
-                          </div>
-                          <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">가격</p>
                             <div className="flex items-center gap-4 font-body-2-r text-black">
                               <p>{(selectedProduct.price ?? 0).toLocaleString()}</p>
@@ -592,11 +588,19 @@ const DeviceSearchPage = () => {
                           </div>
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">충전방식</p>
-                            <p className="font-body-2-r text-black">USB-C</p>
+                            <p className="font-body-2-r text-black">
+                              {selectedDevice?.specifications?.chargingPort
+                                ? String(selectedDevice.specifications.chargingPort).replace('_', '-')
+                                : '-'}
+                            </p>
                           </div>
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">출시일</p>
-                            <p className="font-body-2-r text-black">2023년 9월</p>
+                            <p className="font-body-2-r text-black">
+                              {selectedDevice?.releaseDate
+                                ? new Date(selectedDevice.releaseDate).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long' })
+                                : '-'}
+                            </p>
                           </div>
                         </div>
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -611,11 +611,6 @@ const DeviceSearchPage = () => {
                           </div>
                         </div>
 
-                        {/* Hashtags */}
-                        <div className="flex items-center gap-16">
-                          <ProductLife label="office" />
-                          <ProductLife label="portability" />
-                        </div>
                       </div>
                     </div>
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -22,9 +22,10 @@ import {
   PRICE_OPTIONS,
   SCROLL_CONSTANTS,
 } from '@/constants/devices';
-import { MOCK_PRODUCTS } from '@/constants/mockData';
 import { ROUTES } from '@/constants/routes';
-import { type ModalView } from '@/types/devices';
+import { type ModalView, type SearchDevice } from '@/types/devices';
+import { useSearchDevices } from '@/apis/devices/searchDevices';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePostComboDevice } from '@/apis/combo/postComboDevices';
@@ -47,6 +48,27 @@ const getCategoryDeviceType = (categoryId: number | null): string | undefined =>
   };
   return mapping[categoryId];
 };
+
+// sortOption을 API sortType으로 변환
+const getSortType = (sortOption: string) => {
+  const mapping: Record<string, 'LATEST' | 'NAME_ASC' | 'PRICE_ASC' | 'PRICE_DESC'> = {
+    'latest': 'LATEST',
+    'alphabetical': 'NAME_ASC',
+    'price-low': 'PRICE_ASC',
+    'price-high': 'PRICE_DESC',
+  };
+  return mapping[sortOption] ?? 'LATEST';
+};
+
+// SearchDevice를 Product 형식으로 변환
+const mapSearchDeviceToProduct = (device: SearchDevice) => ({
+  id: device.deviceId,
+  name: `${device.brandName ?? ''} ${device.name ?? ''}`.trim(),
+  category: device.deviceType ?? '',
+  price: device.price ?? 0,
+  image: device.imageUrl ?? null,
+  colors: [] as string[],
+});
 
 const DeviceSearchPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -97,6 +119,44 @@ const DeviceSearchPage = () => {
     }));
   }, [brandsData]);
 
+  // 기기 검색 API 파라미터 구성
+  const apiSearchParams = useMemo(() => {
+    const deviceType = getCategoryDeviceType(selectedCategory);
+    return {
+      keyword: searchQuery || undefined,
+      size: 24,
+      sortType: getSortType(sortOption),
+      deviceTypes: deviceType ? [deviceType] : undefined,
+      brandIds: selectedBrand ? [Number(selectedBrand)] : undefined,
+    };
+  }, [searchQuery, selectedCategory, sortOption, selectedBrand]);
+
+  // 기기 검색 API 호출
+  const {
+    data: searchData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isSearchLoading,
+    isError: isSearchError,
+  } = useSearchDevices(apiSearchParams);
+
+  // 전체 기기 목록 (모든 페이지 결합)
+  const allDevices = useMemo(() =>
+    searchData?.pages.flatMap(page => page.devices) ?? [],
+    [searchData]
+  );
+
+  // 무한 스크롤 트리거
+  const { targetRef, isIntersecting } = useIntersectionObserver({ rootMargin: '100px' });
+
+  // 스크롤 감지 시 다음 페이지 로드
+  useEffect(() => {
+    if (isIntersecting && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [isIntersecting, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
   // 페이지 마운트 시 상단으로 스크롤
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -108,9 +168,10 @@ const DeviceSearchPage = () => {
   }, [selectedCategory]);
 
   /* 선택된 제품 찾기 */
-  const selectedProduct = selectedProductId
-    ? MOCK_PRODUCTS.find(p => p.id === Number(selectedProductId))
+  const selectedDevice = selectedProductId
+    ? allDevices.find(d => d.deviceId === Number(selectedProductId))
     : null;
+  const selectedProduct = selectedDevice ? mapSearchDeviceToProduct(selectedDevice) : null;
 
   /* 모달 닫기 */
   const handleCloseModal = () => {
@@ -372,7 +433,7 @@ const DeviceSearchPage = () => {
             <div className="flex items-center justify-between pt-80">
             {/* Left side - Result count */}
             <div className="flex items-center gap-2">
-              <p className="font-body-1-sm text-black">40</p>
+              <p className="font-body-1-sm text-black">{allDevices.length}</p>
               <p className="font-body-1-r text-black">개 결과</p>
             </div>
 
@@ -387,18 +448,42 @@ const DeviceSearchPage = () => {
 
         {/* Product Grid */}
         <div ref={productGridRef} className="mx-auto px-120 2xl:px-160">
-          <div className="grid grid-cols-3 2xl:grid-cols-4 gap-x-28 gap-y-164">
-            {MOCK_PRODUCTS.map((product) => (
-              <ProductCard
-                key={product.id}
-                product={product}
-                onClick={() => {
-                  searchParams.set('productId', product.id.toString());
-                  setSearchParams(searchParams);
-                }}
-              />
-            ))}
-          </div>
+          {isSearchLoading ? (
+            <div className="flex justify-center items-center py-100">
+              <p className="font-body-1-r text-gray-400">로딩 중...</p>
+            </div>
+          ) : isSearchError ? (
+            <div className="flex justify-center items-center py-100">
+              <p className="font-body-1-r text-red-500">검색 결과를 불러오는데 실패했습니다.</p>
+            </div>
+          ) : allDevices.length === 0 ? (
+            <div className="flex justify-center items-center py-100">
+              <p className="font-body-1-r text-gray-400">검색 결과가 없습니다.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 2xl:grid-cols-4 gap-x-28 gap-y-164">
+              {allDevices.map((device) => (
+                <ProductCard
+                  key={device.deviceId}
+                  product={mapSearchDeviceToProduct(device)}
+                  onClick={() => {
+                    searchParams.set('productId', device.deviceId.toString());
+                    setSearchParams(searchParams);
+                  }}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* 무한 스크롤 트리거 */}
+          <div ref={targetRef} className="h-20" />
+
+          {/* 로딩 인디케이터 */}
+          {isFetchingNextPage && (
+            <div className="flex justify-center py-40">
+              <p className="font-body-1-r text-gray-400">더 불러오는 중...</p>
+            </div>
+          )}
         </div>
 
         {/* Top Button - 3행이 보일 때만 표시 */}
@@ -457,7 +542,7 @@ const DeviceSearchPage = () => {
                         <p className="font-heading-1 text-blue-600">{selectedProduct.name}</p>
                         <div className="flex items-center gap-8 font-heading-2 text-black">
                           <p>₩</p>
-                          <p>{selectedProduct.price.toLocaleString()}</p>
+                          <p>{(selectedProduct.price ?? 0).toLocaleString()}</p>
                         </div>
                       </div>
                     </div>
@@ -482,7 +567,7 @@ const DeviceSearchPage = () => {
                           </div>
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">브랜드</p>
-                            <p className="font-body-2-r text-black">Apple</p>
+                            <p className="font-body-2-r text-black">{selectedDevice?.brandName ?? '-'}</p>
                           </div>
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">색상</p>
@@ -491,7 +576,7 @@ const DeviceSearchPage = () => {
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">가격</p>
                             <div className="flex items-center gap-4 font-body-2-r text-black">
-                              <p>{selectedProduct.price.toLocaleString()}</p>
+                              <p>{(selectedProduct.price ?? 0).toLocaleString()}</p>
                               <p>원</p>
                             </div>
                           </div>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -4,7 +4,6 @@ import GNB from '@/components/Home/GNB';
 import ProductCard from '@/components/ProductCard/ProductCard';
 import PrimaryButton from '@/components/Button/PrimaryButton';
 import CombinationDeviceCard from '@/components/Combination/CombinationDeviceCard';
-import ProductLife from '@/components/ProductCard/ProductLife';
 import FilterDropdown from '@/components/Filter/FilterDropdown';
 import SortDropdown from '@/components/Filter/SortDropdown';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -595,22 +594,22 @@ const DeviceSearchPage = () => {
                               <p>원</p>
                             </div>
                           </div>
-                          {selectedDevice?.specifications?.screenInch && (
+                          {selectedDevice?.specifications?.screenInch ? (
                             <div className="flex items-center gap-24">
                               <p className="font-body-2-r text-gray-400 w-80">인치</p>
                               <p className="font-body-2-r text-black">
-                                {selectedDevice.specifications.screenInch}
+                                {String(selectedDevice.specifications.screenInch)}
                               </p>
                             </div>
-                          )}
-                          {selectedDevice?.specifications?.chargingPort && (
+                          ) : null}
+                          {selectedDevice?.specifications?.chargingPort ? (
                             <div className="flex items-center gap-24">
                               <p className="font-body-2-r text-gray-400 w-80">충전방식</p>
                               <p className="font-body-2-r text-black">
                                 {String(selectedDevice.specifications.chargingPort).replace('_', '-')}
                               </p>
                             </div>
-                          )}
+                          ) : null}
                           {selectedDevice?.releaseDate && (
                             <div className="flex items-center gap-24">
                               <p className="font-body-2-r text-gray-400 w-80">출시일</p>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -582,10 +582,12 @@ const DeviceSearchPage = () => {
                             <p className="font-body-2-r text-gray-400 w-80">카테고리</p>
                             <p className="font-body-2-r text-black">{selectedProduct.category}</p>
                           </div>
-                          <div className="flex items-center gap-24">
-                            <p className="font-body-2-r text-gray-400 w-80">브랜드</p>
-                            <p className="font-body-2-r text-black">{selectedDevice?.brandName ?? '-'}</p>
-                          </div>
+                          {selectedDevice?.brandName && (
+                            <div className="flex items-center gap-24">
+                              <p className="font-body-2-r text-gray-400 w-80">브랜드</p>
+                              <p className="font-body-2-r text-black">{selectedDevice.brandName}</p>
+                            </div>
+                          )}
                           <div className="flex items-center gap-24">
                             <p className="font-body-2-r text-gray-400 w-80">가격</p>
                             <div className="flex items-center gap-4 font-body-2-r text-black">
@@ -593,22 +595,22 @@ const DeviceSearchPage = () => {
                               <p>원</p>
                             </div>
                           </div>
-                          <div className="flex items-center gap-24">
-                            <p className="font-body-2-r text-gray-400 w-80">충전방식</p>
-                            <p className="font-body-2-r text-black">
-                              {selectedDevice?.specifications?.chargingPort
-                                ? String(selectedDevice.specifications.chargingPort).replace('_', '-')
-                                : '-'}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-24">
-                            <p className="font-body-2-r text-gray-400 w-80">출시일</p>
-                            <p className="font-body-2-r text-black">
-                              {selectedDevice?.releaseDate
-                                ? new Date(selectedDevice.releaseDate).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long' })
-                                : '-'}
-                            </p>
-                          </div>
+                          {selectedDevice?.specifications?.chargingPort && (
+                            <div className="flex items-center gap-24">
+                              <p className="font-body-2-r text-gray-400 w-80">충전방식</p>
+                              <p className="font-body-2-r text-black">
+                                {String(selectedDevice.specifications.chargingPort).replace('_', '-')}
+                              </p>
+                            </div>
+                          )}
+                          {selectedDevice?.releaseDate && (
+                            <div className="flex items-center gap-24">
+                              <p className="font-body-2-r text-gray-400 w-80">출시일</p>
+                              <p className="font-body-2-r text-black">
+                                {new Date(selectedDevice.releaseDate).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long' })}
+                              </p>
+                            </div>
+                          )}
                         </div>
 
                       </div>

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -595,6 +595,14 @@ const DeviceSearchPage = () => {
                               <p>원</p>
                             </div>
                           </div>
+                          {selectedDevice?.specifications?.screenInch && (
+                            <div className="flex items-center gap-24">
+                              <p className="font-body-2-r text-gray-400 w-80">인치</p>
+                              <p className="font-body-2-r text-black">
+                                {selectedDevice.specifications.screenInch}
+                              </p>
+                            </div>
+                          )}
                           {selectedDevice?.specifications?.chargingPort && (
                             <div className="flex items-center gap-24">
                               <p className="font-body-2-r text-gray-400 w-80">충전방식</p>

--- a/src/types/devices.ts
+++ b/src/types/devices.ts
@@ -1,4 +1,5 @@
 import { type CombinationName, type CombinationStatus } from '@/constants/combination';
+import type { CommonResponse } from '@/types/common';
 
 export type AuthStatus = 'logout' | 'login';
 export type ModalView = 'device' | 'combination' | 'combinationDetail';
@@ -27,3 +28,38 @@ export type UserCombination = {
   createdAt?: string;
   tags: CombinationTagType[];
 };
+
+// 기기 검색 API 파라미터
+export interface SearchDevicesParams {
+  keyword?: string;
+  cursor?: string;
+  size?: number;
+  sortType?: 'LATEST' | 'NAME_ASC' | 'PRICE_ASC' | 'PRICE_DESC';
+  deviceTypes?: string[];
+  minPrice?: number;
+  maxPrice?: number;
+  brandIds?: number[];
+}
+
+// 검색 결과 기기
+export interface SearchDevice {
+  deviceId: number;
+  deviceType: string;
+  brandName: string;
+  name: string;
+  price: number;
+  priceCurrency: string;
+  imageUrl: string;
+  releaseDate: string;
+  specifications: Record<string, unknown>;
+}
+
+// 검색 결과
+export interface DeviceSearchResult {
+  devices: SearchDevice[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}
+
+// API 응답
+export type GetDevicesSearchResponse = CommonResponse<DeviceSearchResult>;


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #128 

## 🔍 구현한 내용

 📝 변경 사항        
                                                                                                                                                                                                                                              
  1. 제품 이미지 표시 구현

  구현 파일

  - 컴포넌트: src/components/ProductCard/ProductCard.tsx
  - 타입 활용: Product.image (이미지 URL)
  - 사용처: DeviceSearchPage - Product Grid의 모든 제품 카드

  주요 기능

  - 이미지 렌더링: API로 받아온 imageUrl을 <img> 태그로 표시
  - 정사각형 비율 유지: aspect-square + object-cover로 모든 이미지를 1:1 비율로 표시
  - Fallback 처리: 이미지가 없을 경우 회색 플레이스홀더(bg-gray-200) 표시
  - 반응형 대응: w-full h-full로 컨테이너 크기에 맞춰 자동 조정
  - relative + absolute inset-0: 이미지를 부모 컨테이너에 정확히 맞춤
  - object-cover: 이미지 비율을 유지하면서 컨테이너 채우기
  - overflow-hidden: 이미지가 컨테이너 밖으로 넘치지 않도록 제한

==========================================

  2. 브랜드명 중복 표시 문제 해결

  구현 파일

  - 페이지: src/pages/devices/DeviceSearchPage.tsx
  - 함수: mapSearchDeviceToProduct() (Line 64-72)
  - 타입: SearchDevice → Product 변환 로직

  문제 상황

  - Before: "Samsung Samsung Galaxy", "LG LG Gram" 등 브랜드명 중복 표시
  - 원인: API의 device.name이 이미 브랜드명을 포함하는 경우가 있어, brandName + name 조합 시 중복 발생

  해결 방법

 이미 브랜드명 포함 시 그대로 사용
 없으면 추가하여 표시

  결과

  -  "Samsung Samsung Galaxy" → "Samsung Galaxy"
  -  "MacBook Pro 14" → "Apple MacBook Pro 14"
  -   모든 제품명이 일관되고 자연스럽게 표시

==========================================

  3. 검색 시 깜빡임 현상 해결

  구현 파일

  - 페이지: src/pages/devices/DeviceSearchPage.tsx
  - 영향 범위: Product Grid 렌더링 로직 (Line 462-476)
  - Hook: useSearchDevices (React Query)

  문제 상황

  - Before: 검색어/필터 변경 시마다 "로딩 중..." 메시지가 표시되며 화면 깜빡임
  - 원인: isSearchLoading이 true일 때 기존 제품 목록을 숨기고 로딩 메시지만 표시

  주요 개선 사항

  - 초기 로딩: 데이터가 없을 때만 로딩 메시지 표시
  - 백그라운드 로딩: 데이터가 있으면 기존 제품을 유지하면서 새 데이터를 백그라운드에서 로드
  - 무한 스크롤: isFetchingNextPage 상태는 별도 처리하여 하단에 "더 불러오는 중..." 표시
  - 에러 처리: 데이터가 있을 때는 에러가 나도 기존 데이터 유지

  UX 개선 효과

  -  필터/정렬 변경 시 화면이 깨끗하게 전환 (깜빡임 없음)
  -  사용자가 이전 결과를 계속 볼 수 있어 맥락 유지

==========================================

  🔗 API 연동

  - 엔드포인트: GET /api/devices/search
  - Hook: useSearchDevices (Infinite Query)
  - 파라미터:
    - keyword: 검색어
    - deviceTypes: 선택된 카테고리
    - brandIds: 선택된 브랜드
    - sortType: 정렬 방식 (LATEST, NAME_ASC, PRICE_ASC, PRICE_DESC)
    - size: 페이지당 개수 (24개)

==========================================

  PR 리뷰 반영 ->  로딩 상태 개선

  - 초기 로딩 시 LoadingSpinner 컴포넌트 적용
  - 무한 스크롤 추가 로딩은 텍스트 유지 ("더 불러오는 중...")
 
==========================================

  추가 변경: 제품 상세 모달 스펙 정보 개선

  API 데이터 연동:
  - 충전방식: specifications.chargingPort API 데이터로 변경
    - 형식: USB_C → USB-C 변환
  - 출시일: releaseDate API 데이터로 변경
    - 형식: 2025-09-19 → 2025년 9월 변환
  - 화면 인치: specifications.screenInch 추가 표시
    - 스마트폰, 노트북, 태블릿에만 표시됨

  UI 정리:
  - 색상: API 미제공으로 행 삭제
  - 라이프스타일 태그: 하드코딩된 #office #portability 삭제

  조건부 렌더링:
  - 데이터가 없는 스펙 행은 완전히 숨김 처리
    - 브랜드, 충전방식, 출시일, 화면 인치 → 데이터 있을 때만 표시
    - 헤드폰, 키보드 등은 충전방식/화면 인치 행이 자동으로 숨겨짐

==========================================

  추가 발견사항: 제품 이미지 표시

  - 제품 상세 모달에 API 이미지(imageUrl) 표시
  - object-contain 사용하여 이미지 비율 유지
  - 이미지가 있으면 배경 흰색, 없으면 회색으로 구분

==========================================

  반응형 개선

  - 페이지 루트 컨테이너에 max-w-[100vw] overflow-x-hidden 적용
  - 1440~1920px 뷰포트에서 좌우 마진이 대칭적으로 작동

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게


  1. 이미지 표시

  - API로 받은 이미지가 정상적으로 표시됨
  - 이미지가 없는 제품은 회색 플레이스홀더 표시
  - 이미지 비율이 정사각형으로 유지됨

  2. 브랜드명

  - 브랜드명이 중복되지 않고 표시됨
  - 모든 제품명이 브랜드명을 포함함

  3. 검색 UX

  - 초기 진입 시 로딩 메시지 표시
  - 검색어 입력 시 깜빡임 없이 부드럽게 전환
  - 카테고리/필터 변경 시 기존 제품 유지 후 교체
  - 무한 스크롤 동작 확인

  4. 상세 모달
  - 스마트폰 클릭 → 인치, 충전방식, 출시일, 이미지 표시 확인
  - 노트북/태블릿 클릭 → 인치 표시 확인
  - 헤드폰/키보드 클릭 → 충전방식/인치 행 숨겨짐 확인
  - 이미지 없는 제품 → 회색 배경 표시 확인
  - 반응형 동작 확인 (1440~1920px)
