### PR TITLE
feat: 최근에 본 기기 저장 API 연동, 기기 상세보기에 태그 구현

### DIFF
--- a/src/apis/recentlyViewed/postRecentlyViewed.ts
+++ b/src/apis/recentlyViewed/postRecentlyViewed.ts
@@ -1,0 +1,24 @@
+import { axiosInstance } from '@/apis/axios/axios';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKey } from '@/constants/queryKey';
+import type { CommonResponse } from '@/types/common';
+
+// 최근 본 기기 기록 API
+export const postRecentlyViewed = async (deviceId: number): Promise<CommonResponse> => {
+  const { data } = await axiosInstance.post<CommonResponse>(
+    `/api/recently-viewed/${deviceId}`
+  );
+  return data;
+};
+
+// 최근 본 기기 기록 Mutation
+export const usePostRecentlyViewed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (deviceId: number) => postRecentlyViewed(deviceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKey.RECENTLY_VIEWED] });
+    },
+  });
+};

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import StarIcon from '@/assets/icons/star.svg?react';
 import type { ComboListItem, ComboDevice } from '@/types/combo/combo';
+import type { CombinationStatus } from '@/constants/combination';
+import CombinationTag from '@/components/Combination/CombinationTag';
+import { useComboEvaluation } from '@/apis/combo/getComboEvaluation';
 
 type CombinationDeviceCardProps = {
   combination: ComboListItem;
@@ -28,6 +31,9 @@ const CombinationDeviceCard = ({
   index,
 }: CombinationDeviceCardProps) => {
   const [internalExpanded, setInternalExpanded] = useState(false);
+
+  // 평가 데이터 조회 (마이페이지와 동일한 데이터 소스)
+  const { data: evaluation } = useComboEvaluation(combination.comboId);
 
   const isControlled = expanded !== undefined;
   const showAllDevices = isControlled ? expanded : internalExpanded;
@@ -60,7 +66,7 @@ const CombinationDeviceCard = ({
   return (
     <div className={className}>
       {/* 조합 정보 */}
-      <div className="flex flex-col gap-24 pl-20 py-24 flex-shrink-0">
+      <div className="flex flex-col gap-16 pl-20 pt-24 flex-shrink-0">
         {/* 조합명 */}
         <div className="flex flex-col gap-8">
           {/* 조합 번호 */}
@@ -73,18 +79,24 @@ const CombinationDeviceCard = ({
             {combination.isPinned && <StarIcon className="w-22 h-22 -mt-3" />}
           </div>
         </div>
-        {/* Tags */}
-        <div className="flex gap-12 -ml-4">
-          <span className="bg-blue-200 text-blue-700 font-body-2-sm px-12 py-8 rounded-full">
-            기기 {combination.deviceCount}개
-          </span>
-          <span className="bg-gray-200 text-gray-700 font-body-2-sm px-12 py-8 rounded-full">
-            ₩{combination.totalPrice.toLocaleString()}
-          </span>
+        {/* 평가 태그 */}
+        <div className="flex gap-8 -ml-4">
+          <CombinationTag
+            name="연동성"
+            status={(evaluation?.connectivityGrade || '-') as CombinationStatus}
+          />
+          <CombinationTag
+            name="편의성"
+            status={(evaluation?.convenienceGrade || '-') as CombinationStatus}
+          />
+          <CombinationTag
+            name="라이프스타일"
+            status={(evaluation?.lifestyleGrade || '-') as CombinationStatus}
+          />
         </div>
       </div>
 
-      {/* 기기 그리드 */}
+      {/* 기기 그리드 - 태그와의 마진 24px (mt-24) */}
       <div className="pl-8 mt-24 relative">
         <div className={`grid ${gridColsClass} gap-x-28 gap-y-12`}>
           {displayedDevices.map((device) => (
@@ -143,3 +155,4 @@ const CombinationDeviceCard = ({
 };
 
 export default CombinationDeviceCard;
+

--- a/src/components/Combination/CombinationDeviceCard.tsx
+++ b/src/components/Combination/CombinationDeviceCard.tsx
@@ -92,7 +92,15 @@ const CombinationDeviceCard = ({
               key={device.deviceId}
               className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 ${deviceCardWidth} flex items-center gap-12`}
             >
-              <div className={`${deviceImageSize} bg-gray-200 flex-shrink-0`} />
+              <div className={`${deviceImageSize} bg-gray-200 flex-shrink-0 overflow-hidden relative`}>
+                {device.imageUrl && (
+                  <img
+                    src={device.imageUrl}
+                    alt={device.name}
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                )}
+              </div>
               <div className="flex flex-col gap-4 min-w-0">
                 <p className="font-body-3-sm text-black truncate">{device.name}</p>
                 <p className="font-body-4-r text-gray-300">{device.brandName}</p>

--- a/src/components/Combination/CombinationTag.tsx
+++ b/src/components/Combination/CombinationTag.tsx
@@ -12,6 +12,10 @@ type CombinationTagProps = {
 };
 
 const CombinationTag = ({ name, status, className = '' }: CombinationTagProps) => {
+  // status가 유효하지 않을 경우를 대비한 안전한 스타일 추출
+  const statusStyle = COMBINATION_STATUS_STYLE_MAP[status] || COMBINATION_STATUS_STYLE_MAP['-'];
+  const displayStatus = status || '-';
+
   return (
     <span
       className={`
@@ -24,7 +28,7 @@ const CombinationTag = ({ name, status, className = '' }: CombinationTagProps) =
       `}
     >
       <span>{name}:</span>
-      <span className={COMBINATION_STATUS_STYLE_MAP[status]}>{status}</span>
+      <span className={statusStyle}>{displayStatus}</span>
     </span>
   );
 };

--- a/src/components/DeviceSearch/CombinationSelectModal.tsx
+++ b/src/components/DeviceSearch/CombinationSelectModal.tsx
@@ -1,8 +1,11 @@
 import type { ComboListItem } from '@/types/combo/combo';
+import type { CombinationStatus } from '@/constants/combination';
+import CombinationTag from '@/components/Combination/CombinationTag';
 import BackIcon from '@/assets/icons/back.svg?react';
 import XIcon from '@/assets/icons/X.svg?react';
 import StarIcon from '@/assets/icons/star.svg?react';
 import MoreIcon from '@/assets/icons/more.svg?react';
+import { useComboEvaluation } from '@/apis/combo/getComboEvaluation';
 
 interface CombinationSelectModalProps {
   combos: ComboListItem[];
@@ -10,6 +13,61 @@ interface CombinationSelectModalProps {
   onBack: () => void;
   onClose: () => void;
 }
+
+/**
+ * 개별 조합 아이템 컴포넌트
+ * 마이페이지 상세 정보와 동일한 평가 데이터를 가져와서 표시합니다.
+ */
+const CombinationSelectItem = ({
+  comboItem,
+  index,
+  onSelect,
+}: {
+  comboItem: ComboListItem;
+  index: number;
+  onSelect: (id: number) => void;
+}) => {
+  // 각 조합의 평가 정보를 상세 API에서 가져옴 (마이페이지와 동일한 데이터 소스)
+  const { data: evaluation } = useComboEvaluation(comboItem.comboId);
+
+  return (
+    <button
+      onClick={() => onSelect(comboItem.comboId)}
+      className="flex items-center justify-between pl-20 pr-36 py-24 hover:bg-gray-50 transition-colors border-b border-gray-200 cursor-pointer last:border-none"
+    >
+      {/* 좌측: 조합 정보 */}
+      <div className="flex flex-col gap-16 items-start">
+        {/* 조합 번호 + 조합명 */}
+        <div className="flex flex-col gap-8 items-start">
+          <p className="font-body-3-r text-gray-400">조합 {index + 1}</p>
+          <div className="flex items-center gap-8">
+            <p className="font-body-1-sm text-black">{comboItem.comboName}</p>
+            {comboItem.isPinned && <StarIcon className="w-22 h-22 -mt-3" />}
+          </div>
+        </div>
+
+        {/* 평가 태그: evaluation 데이터가 있으면 등급을, 없으면 '-' 표시 */}
+        <div className="flex gap-8">
+          <CombinationTag
+            name="연동성"
+            status={(evaluation?.connectivityGrade || '-') as CombinationStatus}
+          />
+          <CombinationTag
+            name="편의성"
+            status={(evaluation?.convenienceGrade || '-') as CombinationStatus}
+          />
+          <CombinationTag
+            name="라이프스타일"
+            status={(evaluation?.lifestyleGrade || '-') as CombinationStatus}
+          />
+        </div>
+      </div>
+
+      {/* 우측: More 아이콘 */}
+      <MoreIcon className="w-20 h-36 text-gray-400" />
+    </button>
+  );
+};
 
 const CombinationSelectModal = ({
   combos,
@@ -48,36 +106,12 @@ const CombinationSelectModal = ({
         {/* Combination List */}
         <div className="flex flex-col ml-20 overflow-y-auto h-full scrollbar-minimal">
           {combos.map((comboItem, index) => (
-            <button
+            <CombinationSelectItem
               key={comboItem.comboId}
-              onClick={() => onSelectCombination(comboItem.comboId)}
-              className="flex items-center justify-between pl-20 pr-36 py-24 hover:bg-gray-50 transition-colors border-b border-gray-200 cursor-pointer last:border-none"
-            >
-              {/* 좌측: 조합 정보 */}
-              <div className="flex flex-col gap-24 items-start">
-                {/* 조합 번호 + 조합명 */}
-                <div className="flex flex-col gap-8 items-start">
-                  <p className="font-body-3-r text-gray-400">조합 {index + 1}</p>
-                  {/* 조합명 + 대표조합 star */}
-                  <div className="flex items-center gap-8">
-                    <p className="font-body-1-sm text-black">{comboItem.comboName}</p>
-                    {comboItem.isPinned && <StarIcon className="w-22 h-22 -mt-3" />}
-                  </div>
-                </div>
-                {/* 기기 수 + 총 가격 */}
-                <div className="flex gap-12">
-                  <span className="bg-blue-200 text-blue-700 font-body-2-sm px-12 py-8 rounded-full">
-                    기기 {comboItem.deviceCount}개
-                  </span>
-                  <span className="bg-gray-200 text-gray-700 font-body-2-sm px-12 py-8 rounded-full">
-                    ₩{comboItem.totalPrice.toLocaleString()}
-                  </span>
-                </div>
-              </div>
-
-              {/* 우측: More 아이콘 */}
-              <MoreIcon className="w-20 h-36 text-gray-400" />
-            </button>
+              comboItem={comboItem}
+              index={index}
+              onSelect={onSelectCombination}
+            />
           ))}
         </div>
       </div>
@@ -86,3 +120,5 @@ const CombinationSelectModal = ({
 };
 
 export default CombinationSelectModal;
+
+

--- a/src/components/DeviceSearch/DeviceDetailModal.tsx
+++ b/src/components/DeviceSearch/DeviceDetailModal.tsx
@@ -20,7 +20,7 @@ const DeviceDetailModal = ({
   isProfileLoading,
   onClose,
 }: DeviceDetailModalProps) => {
-  const rawTags = getDeviceLifestyleTags(device);
+  const rawTags: string[] = getDeviceLifestyleTags(device);
 
   return (
     <div className="flex flex-col items-end gap-20 pointer-events-auto">
@@ -123,7 +123,7 @@ const DeviceDetailModal = ({
               {/* Lifestyle Tags */}
               {rawTags.length > 0 && (
                 <div className="flex flex-wrap gap-12">
-                  {rawTags.map((tag) => (
+                  {rawTags.map((tag: string) => (
                     <RoundedLifestyleTag key={tag} label={`# ${tag}`} />
                   ))}
                 </div>

--- a/src/components/DeviceSearch/DeviceDetailModal.tsx
+++ b/src/components/DeviceSearch/DeviceDetailModal.tsx
@@ -2,6 +2,8 @@ import type { Product } from '@/types/product';
 import type { SearchDevice } from '@/types/devices';
 import PrimaryButton from '@/components/Button/PrimaryButton';
 import XIcon from '@/assets/icons/X.svg?react';
+import RoundedLifestyleTag from '@/components/Lifestyle/RoundedLifestyleTag';
+import { getDeviceLifestyleTags } from '@/utils/tag/deviceLifestyleTags';
 
 interface DeviceDetailModalProps {
   product: Product;
@@ -18,6 +20,8 @@ const DeviceDetailModal = ({
   isProfileLoading,
   onClose,
 }: DeviceDetailModalProps) => {
+  const rawTags = getDeviceLifestyleTags(device);
+
   return (
     <div className="flex flex-col items-end gap-20 pointer-events-auto">
       {/* Close Button - 카드 바깥 */}
@@ -66,9 +70,9 @@ const DeviceDetailModal = ({
             </div>
 
             {/* Right Section - Specs */}
-            <div className="w-303 flex flex-col gap-40">
+            <div className="w-303 flex flex-col pl-16">
               {/* Product Info Table */}
-              <div className="flex flex-col gap-20 pl-16">
+              <div className="flex flex-col gap-20 mb-40">
                 <div className="flex items-center gap-24">
                   <p className="font-body-2-r text-gray-400 w-80 flex-shrink-0">모델명</p>
                   <p className="font-body-2-r text-black line-clamp-1">{product.name}</p>
@@ -116,6 +120,14 @@ const DeviceDetailModal = ({
                 )}
               </div>
 
+              {/* Lifestyle Tags */}
+              {rawTags.length > 0 && (
+                <div className="flex flex-wrap gap-12">
+                  {rawTags.map((tag) => (
+                    <RoundedLifestyleTag key={tag} label={`# ${tag}`} />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/components/MyPage/CombinationCard.tsx
+++ b/src/components/MyPage/CombinationCard.tsx
@@ -143,7 +143,15 @@ const CombinationCard = ({
               key={device.deviceId}
               className="bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12"
             >
-              <div className="w-64 h-64 bg-gray-200 flex-shrink-0" />
+              <div className="w-64 h-64 bg-gray-200 flex-shrink-0 overflow-hidden relative">
+                {device.imageUrl && (
+                  <img
+                    src={device.imageUrl}
+                    alt={device.name}
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                )}
+              </div>
               <div className="flex flex-col gap-4 flex-1">
                 <p className="font-body-3-sm text-black truncate w-120">{device.name}</p>
                 <p className="font-body-4-r text-gray-300">{device.brandName}</p>

--- a/src/components/MyPage/CombinationDetailView.tsx
+++ b/src/components/MyPage/CombinationDetailView.tsx
@@ -19,6 +19,7 @@ interface Device {
   name: string;
   brandName?: string;
   deviceType?: string;
+  imageUrl?: string;
 }
 
 interface EvaluationCard {
@@ -151,7 +152,14 @@ const CombinationDetailView = ({
               onClick={() => window.open(`/devices?productId=${device.deviceId}`, '_blank')}
               className={`bg-white rounded-card shadow-[0_0_4px_rgba(0,0,0,0.1)] p-12 w-244 flex items-center gap-12 border cursor-pointer hover:shadow-[0_0_7px_#57a0ff] transition-shadow ${selectedDevices.includes(device.deviceId) ? 'border-blue-600' : 'border-transparent'}`}
             >
-              <div className="w-64 h-64 bg-gray-200 flex-shrink-0 relative group/image">
+              <div className="w-64 h-64 bg-gray-200 flex-shrink-0 relative group/image overflow-hidden">
+                {device.imageUrl && (
+                  <img
+                    src={device.imageUrl}
+                    alt={device.name}
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                )}
                 {/* 호버 오버레이 */}
                 <div className="absolute inset-0 bg-black/50 opacity-0 group-hover/image:opacity-100 transition-opacity flex items-center justify-center">
                   <span className="bg-white px-8 py-4 rounded-tag font-caption-r text-black">

--- a/src/hooks/useAddToCombination.ts
+++ b/src/hooks/useAddToCombination.ts
@@ -173,18 +173,6 @@ export const useAddToCombination = ({
     ? combinationDevices.some(device => device.deviceId === Number(selectedProductId))
     : false;
 
-  /* 모달 열렸을 때 y 스크롤 방지 */
-  useEffect(() => {
-    if (selectedProductId) {
-      document.documentElement.style.overflowY = 'hidden';
-    } else {
-      document.documentElement.style.overflowY = 'auto';
-    }
-    return () => {
-      document.documentElement.style.overflowY = 'auto';
-    };
-  }, [selectedProductId]);
-
   return {
     modalView,
     setModalView,

--- a/src/hooks/useAddToCombination.ts
+++ b/src/hooks/useAddToCombination.ts
@@ -6,6 +6,7 @@ import { useGetCombos } from '@/apis/combo/getCombos';
 import { useGetCombo } from '@/apis/combo/getComboId';
 import { usePostComboDevice } from '@/apis/combo/postComboDevices';
 import { useGetUserProfile } from '@/apis/mypage/getUserProfile';
+import { usePostRecentlyViewed } from '@/apis/recentlyViewed/postRecentlyViewed';
 import { hasAccessToken, hasCompletedOnboarding } from '@/utils/authStorage';
 
 interface UseAddToCombinationParams {
@@ -33,11 +34,19 @@ export const useAddToCombination = ({
   // API hooks
   const { data: combos = [] } = useGetCombos();
   const { mutate: addDeviceToCombo, isPending: isAddingDevice } = usePostComboDevice();
+  const { mutate: recordRecentlyViewed } = usePostRecentlyViewed();
 
   const [selectedCombinationId, setSelectedCombinationId] = useState<number | null>(null);
   const [showAllDevices, setShowAllDevices] = useState(false);
   const [showSaveCompleteModal, setShowSaveCompleteModal] = useState(false);
   const [isFadingOut, setIsFadingOut] = useState(false);
+
+  // 모달 열릴 때 최근 본 기기 기록 (로그인 상태에서만)
+  useEffect(() => {
+    if (isLoggedIn && selectedProductId) {
+      recordRecentlyViewed(Number(selectedProductId));
+    }
+  }, [selectedProductId]);
 
   // 선택된 조합의 상세 정보 조회
   const { data: comboDetail } = useGetCombo(selectedCombinationId);

--- a/src/hooks/useAddToCombination.ts
+++ b/src/hooks/useAddToCombination.ts
@@ -61,12 +61,7 @@ export const useAddToCombination = ({
 
   // 에러 핸들러 (공통)
   const handleComboError = (error: unknown) => {
-    const axiosError = error as { response?: { status?: number } };
-    if (axiosError?.response?.status === 400) {
-      alert('이미 조합에 추가된 기기입니다.');
-    } else {
-      console.error('기기 추가 실패:', error);
-    }
+    console.error('기기 추가 실패:', error);
   };
 
   /* 내 조합에 담기 */

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -49,18 +49,25 @@ const DeviceSearchPage = () => {
     : null;
   const selectedProduct = selectedDevice ? mapSearchDeviceToProduct(selectedDevice) : null;
 
-  /* 모달 열림 상태 확인 및 스크롤 잠금 */
-  const isModalOpen = !!selectedProduct || combo.showSaveCompleteModal;
+  /* 모달 열림 상태 확인 및 스크롤 잠금 (회색 배경이 보일 때와 동일한 조건) */
+  const isModalOpen = (!!selectedProduct && !combo.showSaveCompleteModal) || combo.showSaveCompleteModal;
 
   useEffect(() => {
     if (isModalOpen) {
-      document.documentElement.style.overflowY = 'hidden';
+      const scrollBarWidth = window.innerWidth - document.documentElement.clientWidth;
+      document.documentElement.style.overflow = 'hidden';
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${scrollBarWidth}px`;
     } else {
-      document.documentElement.style.overflowY = '';
+      document.documentElement.style.overflow = '';
+      document.body.style.overflow = '';
+      document.body.style.paddingRight = '';
     }
 
     return () => {
-      document.documentElement.style.overflowY = '';
+      document.documentElement.style.overflow = '';
+      document.body.style.overflow = '';
+      document.body.style.paddingRight = '';
     };
   }, [isModalOpen]);
 

--- a/src/pages/devices/DeviceSearchPage.tsx
+++ b/src/pages/devices/DeviceSearchPage.tsx
@@ -22,6 +22,7 @@ import { mapSearchDeviceToProduct } from '@/utils/mapSearchDevice';
 import { useDeviceSearch } from '@/hooks/useDeviceSearch';
 import { useScrollState } from '@/hooks/useScrollState';
 import { useAddToCombination } from '@/hooks/useAddToCombination';
+import { useEffect } from 'react';
 
 const DeviceSearchPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -47,6 +48,21 @@ const DeviceSearchPage = () => {
     ? search.allDevices.find(d => d.deviceId === Number(selectedProductId))
     : null;
   const selectedProduct = selectedDevice ? mapSearchDeviceToProduct(selectedDevice) : null;
+
+  /* 모달 열림 상태 확인 및 스크롤 잠금 */
+  const isModalOpen = !!selectedProduct || combo.showSaveCompleteModal;
+
+  useEffect(() => {
+    if (isModalOpen) {
+      document.documentElement.style.overflowY = 'hidden';
+    } else {
+      document.documentElement.style.overflowY = '';
+    }
+
+    return () => {
+      document.documentElement.style.overflowY = '';
+    };
+  }, [isModalOpen]);
 
   return (
     <div className={`min-h-screen bg-white relative max-w-[100vw] overflow-x-hidden ${scroll.isAtBottom ? 'bg-effect-fade-bottom' : ''}`}>

--- a/src/types/combo/combo.ts
+++ b/src/types/combo/combo.ts
@@ -21,6 +21,9 @@ export type ComboListItem = {
   pinnedAt: string | null;
   totalPrice: number;
   currentTotalScore: number;
+  connectivityGrade?: string;
+  convenienceGrade?: string;
+  lifestyleGrade?: string;
   deviceCount: number;
   createdAt: string;
   updatedAt: string;
@@ -35,6 +38,9 @@ export type ComboDetail = {
   pinnedAt: string | null;
   totalPrice: number;
   currentTotalScore: number;
+  connectivityGrade?: string;
+  convenienceGrade?: string;
+  lifestyleGrade?: string;
   evaluatedAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/src/utils/tag/deviceLifestyleTags.ts
+++ b/src/utils/tag/deviceLifestyleTags.ts
@@ -1,0 +1,107 @@
+import type { SearchDevice } from '@/types/devices';
+
+/**
+ * 기기 상세 정보의 specifications를 바탕으로 라이프스타일 스타일 태그를 생성합니다.
+ */
+export const getDeviceLifestyleTags = (device: SearchDevice): string[] => {
+  const { deviceType, specifications: specs } = device;
+  if (!specs) return [];
+
+  const tags: string[] = [];
+
+  switch (deviceType) {
+    case 'SMARTPHONE':
+    case 'TABLET':
+      if (specs.storageGb) tags.push(`${specs.storageGb}GB`);
+      if (specs.screenInch) tags.push(`${specs.screenInch}인치`);
+      break;
+
+    case 'LAPTOP':
+      if (specs.cpu) tags.push(String(specs.cpu));
+      if (specs.screenInch) tags.push(`${specs.screenInch}인치`);
+      break;
+
+    case 'SMARTWATCH':
+      if (specs.caseSizeMm) tags.push(`${specs.caseSizeMm}mm`);
+      if (specs.hasCellular !== undefined) {
+        // 1이면 셀룰러, 0이면 GPS
+        tags.push(Number(specs.hasCellular) === 1 ? '셀룰러' : 'GPS');
+      }
+      break;
+
+    case 'AUDIO':
+      if (Number(specs.hasAnc) === 1) tags.push('ANC');
+      if (specs.totalBatteryLifeHours) tags.push(`${specs.totalBatteryLifeHours}시간`);
+      break;
+
+    case 'KEYBOARD':
+      if (specs.switchType) {
+        const switchMap: Record<string, string> = {
+          BLUE: '청축',
+          RED: '적축',
+          BROWN: '갈축',
+          SCISSOR: '펜타그래프',
+        };
+        const mapped = switchMap[String(specs.switchType).toUpperCase()];
+        if (mapped) tags.push(mapped);
+      }
+      if (specs.connectionType) {
+        tags.push(formatConnectionType(String(specs.connectionType)));
+      }
+      break;
+
+    case 'MOUSE':
+      if (specs.mouseType) {
+        const mouseMap: Record<string, string> = {
+          VERTICAL: '버티컬',
+          TRACKBALL: '트랙볼',
+        };
+        const mapped = mouseMap[String(specs.mouseType).toUpperCase()];
+        if (mapped) tags.push(mapped);
+      }
+      if (specs.connectionType) {
+        tags.push(formatConnectionType(String(specs.connectionType)));
+      }
+      break;
+
+    case 'CHARGER':
+      if (specs.totalPowerW) tags.push(`${specs.totalPowerW}W`);
+      if (Array.isArray(specs.portConfiguration)) {
+        const portConfig = formatPortConfiguration(specs.portConfiguration);
+        if (portConfig) tags.push(portConfig);
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return tags.filter(Boolean);
+};
+
+const formatConnectionType = (type: string): string => {
+  const t = type.toUpperCase();
+  if (t === 'BLUETOOTH') return '블루투스';
+  if (t === 'WIRED') return '유선';
+  // DONGLE이나 기타 무선 방식은 '무선'으로 표기
+  return '무선';
+};
+
+const formatPortConfiguration = (ports: string[]): string => {
+  let cCount = 0;
+  let aCount = 0;
+
+  ports.forEach((port) => {
+    const p = port.toUpperCase();
+    if (p.includes('USB_C')) cCount++;
+    else if (p.includes('USB_A')) aCount++;
+    else if (p.includes('C')) cCount++;
+    else if (p.includes('A')) aCount++;
+  });
+
+  const result = [];
+  if (cCount > 0) result.push(`${cCount}C`);
+  if (aCount > 0) result.push(`${aCount}A`);
+
+  return result.join('');
+};


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #154 

## 🔍 구현한 내용

 - 기기 상세 태그 보기 구현: 기기 상세 모달(DeviceDetailModal) 및 조합카드(CombinationCard, CombinationDeviceCard)에서 
 태그 정보를 시각적으로 확인할 수 있도록 UI를 업데이트했습니다.

 - 최근 본 기기 API 연동: postRecentlyViewed API를 연동하여 사용자가 확인한 기기 목록이 정상적으로 기록되도록 구현했습니다.


## 📢 리뷰어에게

   - 각 컴포넌트(CombinationCard 등)에서 태그가 디자인 가이드에 맞게 출력되는지 확인 부탁드립니다.
   - 최근 본 기기 API 호출 시점이나 데이터 구조가 적절한지 검토 부탁드립니다.