### PR TITLE
fix: 기기에 담는 즉시 반영되도록 구현

### DIFF
--- a/src/apis/combo/postComboDevices.ts
+++ b/src/apis/combo/postComboDevices.ts
@@ -27,8 +27,10 @@ export const usePostComboDevice = () => {
     mutationFn: ({ comboId, deviceId }: { comboId: number; deviceId: number }) =>
       postComboDevice(comboId, { deviceId }),
     onSuccess: (_data, variables) => {
-      // 조합 목록/상세 캐시 무효화
+      // 조합 목록 캐시 무효화
       queryClient.invalidateQueries({ queryKey: [queryKey.COMBOS] });
+      // 조합 상세 정보 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: [queryKey.COMBO_DETAIL] });
       // 조합 평가 폴링 시작
       poll(variables.comboId);
     },


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #163 

## 🔍 구현한 내용

- 기기 상세 모달에서 기기를 담는 즉시 이미 담은 기기인지, 타입인지 구별하도록 구현

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
