### PR TITLE
fix: 온보딩으로 안넘어가지는 오류 수정

### DIFF
--- a/src/pages/auth/SignupProfilePage.tsx
+++ b/src/pages/auth/SignupProfilePage.tsx
@@ -19,7 +19,7 @@ const SignupProfilePage = () => {
   const { account, isEmailVerified, resetSignup } = useSignupStore();
   const { mutateAsync: signup } = usePostJoin();
   const { loginAndFinalize } = useLogin();
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, hasCompletedOnboarding } = useAuth();
 
   // 프로필 정보 입력 폼 상태 관리
   const {
@@ -33,9 +33,13 @@ const SignupProfilePage = () => {
     reValidateMode: 'onChange',
   });
 
-  // 로그인된 상태에서 회원가입 페이지 접근 시 홈으로 리다이렉트
+  // 로그인된 상태에서 회원가입 페이지 접근 시 리다이렉트
+  // (자동 로그인 후 온보딩 미완료 유저는 온보딩으로 보내야 함)
   if (isLoggedIn) {
-    return <Navigate to={ROUTES.home} replace />;
+    const destination = hasCompletedOnboarding
+      ? ROUTES.home
+      : ROUTES.onboarding.lifestyle;
+    return <Navigate to={destination} replace />;
   }
 
   // 이메일, 비밀번호, 중복확인이 모두 완료되었는지 확인


### PR DESCRIPTION
## 📌 관련 이슈번호

close : #166 

## 🔍 구현한 내용
- 회원가입 시 로그인 유저의 접근을 막기 위한 가드가 먼저 실행되어 온보딩 페이지로 안넘어가지는 오류를 수정하였습니다.

## 📸 스크린샷 or 실행 영상

## 📢 리뷰어에게
